### PR TITLE
Update unicode.org links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This is the repository for the [UDHR in Unicode](http://unicode.org/udhr) project.
+This is the repository for the [UDHR in Unicode](https://unicode.org/udhr) project.

--- a/unicode.org/map.js
+++ b/unicode.org/map.js
@@ -34,7 +34,7 @@
        x = x + xsep;
 
        if (stage > 2) {
-         x = x + "<a href='http://www.unicode.org/udhr/d/udhr_" + file + ".html'>" + name + "</a>" }
+         x = x + "<a href='https://www.unicode.org/udhr/d/udhr_" + file + ".html'>" + name + "</a>" }
        else {
          x = x + name; }
 

--- a/unicode.org/xsl/udhrs2html.xsl
+++ b/unicode.org/xsl/udhrs2html.xsl
@@ -95,7 +95,7 @@
 
       <p>This HTML version prepared by the <i>UDHR in Unicode</i>
 	project, <a
-	href='http://www.unicode.org/udhr'>http://www.unicode.org/udhr</a>.</p>
+	href='https://www.unicode.org/udhr'>http://www.unicode.org/udhr</a>.</p>
 
       <hr/>
 
@@ -153,7 +153,7 @@
 
       <p>This HTML version prepared by the <i>UDHR in Unicode</i>
       project, <a
-      href='http://www.unicode.org/udhr'>http://www.unicode.org/udhr</a>.</p>
+      href='https://www.unicode.org/udhr'>http://www.unicode.org/udhr</a>.</p>
 
       <hr/>
 

--- a/unicode.org/xsl/udhrs2txt.xsl
+++ b/unicode.org/xsl/udhrs2txt.xsl
@@ -67,7 +67,7 @@
   <xsl:text>
 &#x00A9; 1996 &#x2013; 2009 The Office of the High Commissioner for Human Rights
 This plain text version prepared by the &#x201C;UDHR in Unicode&#x201D;
-project, http://www.unicode.org/udhr.
+project, https://www.unicode.org/udhr.
 ---
 
 </xsl:text>
@@ -109,7 +109,7 @@ project, http://www.unicode.org/udhr.
 &#x00A9; 1996 &#x2013; 2009 The Office of the High Commissioner for Human Rights
 
 This plain text version prepared by the "UDHR in Unicode" project,
-http://www.unicode.org/udhr.
+https://www.unicode.org/udhr.
 
 ------
 </xsl:text>


### PR DESCRIPTION
Since unicode.org now has auto-redirect to HTTPS.