### PR TITLE
Fixed various transcription errors for Croation xml files

### DIFF
--- a/data/udhr/udhr_hrv.xml
+++ b/data/udhr/udhr_hrv.xml
@@ -3,125 +3,125 @@
 <!--© The Office of the High Commisioner for Human Rights-->
 
 <udhr iso639-3='hrv' xml:lang='hr' key='hrv' n='Croatian' dir='ltr' iso15924='Latn' xmlns="http://www.unhchr.ch/udhr">
-<title>OPĆA DEKLARACIJA O PRAVIMA ĆOVJEKA</title>
+<title>OPĆA DEKLARACIJA O PRAVIMA ČOVJEKA</title>
 <preamble>
 <title>UVOD</title>
-<para>Budući da su priznavanje uroćenog dostojanstva i jednakih i neotućivih prava svih ćlanova ljudske obitelji temelj slobode, pravde i mira u svijetu,</para>
-<para>Budući da su nepoštovanje i preziranje prava ćovjeka imali za posljedicu akte, koji su grubo vrijećali savjest ćovjećanstva i budući da je stvaranje svijeta u kojem će ljudska bića ućivati slobodu govora i vjerovanja i slobodu od straha i nestašice bilo proglašeno kao najviša tećnja obićnih ljudi,</para>
-<para>Budući da je bitno da prava ćovjeka budu zaštićena vladavinom prava, kako ćovjek ne bi bio primoran da kao za posljednjim sredstvom posegne za pobunom protiv tiranije i ugnjetavanja,</para>
-<para>Budući da je bitno da se unaprećuje razvoj prijateljskih odnosa izmeću naroda;</para>
-<para>Budući da su narodi Ujedinjenih naroda ponovno potvrdili u Povelji svoju vjeru u osnovna prava ćovjeka , u dostojanstvo i vrijednost ćovjekove osobe i ravnopravnost muškaraca i ćena i budući da su odlućili unaprećivati društveni napredak i bolji ćivotni standard u široj slobodi,</para>
-<para>Budući da su se drćave ćlanice obvezale da u suradnji s Ujedinjenim narodima postignu unaprećenje općeg poštovanja ćovjekovih prava i osnovnih sloboda i njihovo odrćavanje,</para>
-<para>Budući da je zajednićko razumijevanje tih prava i sloboda od najveće vaćnosti za puno ostvarenje te obveze,</para>
+<para>Budući da su priznavanje urođenog dostojanstva i jednakih i neotuđivih prava svih članova ljudske obitelji temelj slobode, pravde i mira u svijetu,</para>
+<para>Budući da su nepoštovanje i preziranje prava čovjeka imali za posljedicu akte, koji su grubo vrijeđali savjest čovječanstva i budući da je stvaranje svijeta u kojem će ljudska bića uživati slobodu govora i vjerovanja i slobodu od straha i nestašice bilo proglašeno kao najviša težnja običnih ljudi,</para>
+<para>Budući da je bitno da prava čovjeka budu zaštićena vladavinom prava, kako čovjek ne bi bio primoran da kao za posljednjim sredstvom posegne za pobunom protiv tiranije i ugnjetavanja,</para>
+<para>Budući da je bitno da se unapređuje razvoj prijateljskih odnosa između naroda;</para>
+<para>Budući da su narodi Ujedinjenih naroda ponovno potvrdili u Povelji svoju vjeru u osnovna prava čovjeka, u dostojanstvo i vrijednost čovjekove osobe i ravnopravnost muškaraca i žena i budući da su odlučili unapređivati društveni napredak i bolji životni standard u široj slobodi,</para>
+<para>Budući da su se države članice obvezale da u suradnji s Ujedinjenim narodima postignu unapređenje općeg poštovanja čovjekovih prava i osnovnih sloboda i njihovo održavanje,</para>
+<para>Budući da je zajedničko razumijevanje tih prava i sloboda od najveće važnosti za puno ostvarenje te obveze,</para>
 <para>OPĆA SKUPŠTINA</para>
 <para>proglašava</para>
-<para>OVU OPćU DEKLARACIJU O PRAVIMA ćOVJEKA kao zajednićko mjerilo postignuća za sve narode i sve drćave radi toga da bi svaki pojedinac i svaki organ društva, imajući Deklaraciju stalno na umu, tećili da ućenjem i odgojem pridonesu poštovanju tih prava i sloboda i da bi naprednim nacionalnim i mećunarodnim mjerama osigurali njihovo opće i djelotvorno priznanje i odrćavanje, kako meću narodima samih drćava ćlanica, tako i meću narodima onih podrućja koja su pod njihovom sudbenošću.</para>
+<para>OVU OPĆU DEKLARACIJU O PRAVIMA ČOVJEKA kao zajedničko mjerilo postignuća za sve narode i sve države radi toga da bi svaki pojedinac i svaki organ društva, imajući Deklaraciju stalno na umu, težili da učenjem i odgojem pridonesu poštovanju tih prava i sloboda i da bi naprednim nacionalnim i međunarodnim mjerama osigurali njihovo opće i djelotvorno priznanje i održavanje, kako među narodima samih država članica, tako i među narodima onih područja koja su pod njihovom sudbenošću.</para>
 </preamble>
 <article number="1">
-<title>ĆLANAK 1.</title>
-<para>Sva ljudska bića raćaju se slobodna i jednaka u dostojanstvu i pravima. Ona su obdarena razumom i sviješću i treba da jedno prema drugome postupaju u duhu bratstva.</para>
+<title>ČLANAK 1.</title>
+<para>Sva ljudska bića rađaju se slobodna i jednaka u dostojanstvu i pravima. Ona su obdarena razumom i sviješću i treba da jedno prema drugome postupaju u duhu bratstva.</para>
 </article>
 <article number="2">
-<title>ĆLANAK 2.</title>
-<para>Svakome su dostupna sva prava i slobode navedene u ovoj Deklaraciji bez razlike bilo koje vrste, kao što su rasa, boja, spol, jezik,vjera,politićko ili drugo mišljenje, nacionalno ili društveno porijeklo, imovina, roćenje ili drugi pravni poloćaj.</para>
-<para>Nadalje, ne smije se ćiniti bilo kakva razlika na osnovi politićkog, pravnog ili mećunarodnog poloćaja zemlje ili podrućja kojima neka osoba pripada, bilo da je to podrućje neovisno, pod starateljstvom,nesamoupravno, ili da se nalazi ma pod kojima drugim ogranićenjima suverenosti.</para>
+<title>ČLANAK 2.</title>
+<para>Svakome su dostupna sva prava i slobode navedene u ovoj Deklaraciji bez razlike bilo koje vrste, kao što su rasa, boja, spol, jezik, vjera, političko ili drugo mišljenje, nacionalno ili društveno porijeklo, imovina, rođenje ili drugi pravni položaj.</para>
+<para>Nadalje, ne smije se činiti bilo kakva razlika na osnovi političkog, pravnog ili međunarodnog položaja zemlje ili područja kojima neka osoba pripada, bilo da je to područje neovisno, pod starateljstvom, nesamoupravno, ili da se nalazi ma pod kojima drugim ograničenjima suverenosti.</para>
 </article>
 <article number="3">
-<title>ĆLANAK 3.</title>
-<para>Svatko ima pravo na ćivot, slobodu i osobnu sigurnost.</para>
+<title>ČLANAK 3.</title>
+<para>Svatko ima pravo na život, slobodu i osobnu sigurnost.</para>
 </article>
 <article number="4">
-<title>ĆLANAK 4.</title>
-<para>Nitko ne smije biti drćan u ropstvu ili ropskom odnosu; ropstvo i trgovina robljem zabranjuju se u svim svojim oblicima.</para>
+<title>ČLANAK 4.</title>
+<para>Nitko ne smije biti držan u ropstvu ili ropskom odnosu; ropstvo i trgovina robljem zabranjuju se u svim svojim oblicima.</para>
 </article>
 <article number="5">
-<title>ĆLANAK 5.</title>
-<para>Nitko ne smije biti podvrgnut mućenju ili okrutnom,nećovjećnom ili ponićavajućem postupku ili kaćnjavanju.</para>
+<title>ČLANAK 5.</title>
+<para>Nitko ne smije biti podvrgnut mučenju ili okrutnom, nečovječnom ili ponižavajućem postupku ili kažnjavanju.</para>
 </article>
 <article number="6">
-<title>ĆLANAK 6.</title>
+<title>ČLANAK 6.</title>
 <para>Svatko ima pravo da se svagdje pred zakonom priznaje kao osoba.</para>
 </article>
 <article number="7">
-<title>ĆLANAK 7.</title>
+<title>ČLANAK 7.</title>
 <para>Svi su pred zakonom jednaki i imaju pravo, bez ikakve diskriminacije, na jednaku zaštitu zakona. Svi imaju pravo na jednaku zaštitu protiv bilo kakve diskrimininacije kojom se krši ova Deklaracija i protiv svakog poticanja na takvu diskriminaciju.</para>
 </article>
 <article number="8">
-<title>ĆLANAK 8.</title>
-<para>Svatko ima pravo na djelotvorna pravna sredstva putem nadlećnih nacionalnih sudova zbog djela kojima se krše osnovna prava koja mu pripadaju temeljem ustava i zakona.</para>
+<title>ČLANAK 8.</title>
+<para>Svatko ima pravo na djelotvorna pravna sredstva putem nadležnih nacionalnih sudova zbog djela kojima se krše osnovna prava koja mu pripadaju temeljem ustava i zakona.</para>
 </article>
 <article number="9">
-<title>ĆLANAK 9.</title>
+<title>ČLANAK 9.</title>
 <para>Nitko ne smije biti podvrgnut samovoljnom uhićenju, zatvoru ili izgonu.</para>
 </article>
 <article number="10">
-<title>ĆLANAK 10.</title>
-<para>Svatko ima pravo da ga u punoj jednakosti pošteno i javno sasluša neovisan i nepristran sud radi utvrćivanja njegovih prava i obveza i bilo kakve kaznene optućbe protiv njega.</para>
+<title>ČLANAK 10.</title>
+<para>Svatko ima pravo da ga u punoj jednakosti pošteno i javno sasluša neovisan i nepristran sud radi utvrđivanja njegovih prava i obveza i bilo kakve kaznene optužbe protiv njega.</para>
 </article>
 <article number="11">
-<title>ĆLANAK 11.</title>
+<title>ČLANAK 11.</title>
 <orderedlist>
 <listitem>
-<para>Svatko optućen za kazneno djelo ima pravo da se smatra nevinim dok se na osnovi zakona krivnja ne dokaće na javnoj raspravi na kojoj je imao sva jamstva potrebna za svoju obranu.</para>
+<para>Svatko optužen za kazneno djelo ima pravo da se smatra nevinim dok se na osnovi zakona krivnja ne dokaže na javnoj raspravi na kojoj je imao sva jamstva potrebna za svoju obranu.</para>
 </listitem>
 <listitem>
-<para>Nitko se ne smije smatrati krivim za kazneno djelo na osnovi bilo kakvog ćina ili propusta koji nisu bili kazneno djelo prema nacionalnom ili mećunarodnom pravu u vrijeme kada su bili poćinjeni. Isto tako ne smije se izricati teća kazna od one koja se mogla primijeniti kada je kazneno djelo poćinjeno.</para>
+<para>Nitko se ne smije smatrati krivim za kazneno djelo na osnovi bilo kakvog čina ili propusta koji nisu bili kazneno djelo prema nacionalnom ili međunarodnom pravu u vrijeme kada su bili počinjeni. Isto tako ne smije se izricati teža kazna od one koja se mogla primijeniti kada je kazneno djelo počinjeno.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="12">
-<title>ĆLANAK 12.</title>
-<para>Nitko ne smije biti izvrgnut samovoljnom miješanju u svoj privatni ćivot, obitelj, dom ili dopisivanje, niti napadajima na svoju ćast i ugled. Svatko ima pravo na zaštitu zakona protiv takvog miješanja ili napada.</para>
+<title>ČLANAK 12.</title>
+<para>Nitko ne smije biti izvrgnut samovoljnom miješanju u svoj privatni život, obitelj, dom ili dopisivanje, niti napadajima na svoju čast i ugled. Svatko ima pravo na zaštitu zakona protiv takvog miješanja ili napada.</para>
 </article>
 <article number="13">
-<title>ĆLANAK 13.</title>
+<title>ČLANAK 13.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na slobodu kretanja i stanovanja unutar granica svake drćave.</para>
+<para>Svatko ima pravo na slobodu kretanja i stanovanja unutar granica svake države.</para>
 </listitem>
 <listitem>
-<para>Svatko ima pravo napustiti bilo koju zemlju, ukljućujući svoju vlastitu, i vratiti se u svoju zemlju.</para>
+<para>Svatko ima pravo napustiti bilo koju zemlju, uključujući svoju vlastitu, i vratiti se u svoju zemlju.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="14">
-<title>ĆLANAK 14.</title>
+<title>ČLANAK 14.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo traćiti i ućivati u drugim zemljama utoćište pred progonima.</para>
+<para>Svatko ima pravo tražiti i uživati u drugim zemljama utočište pred progonima.</para>
 </listitem>
 <listitem>
-<para>Na to se pravo ne moće pozivati u slućaju progona koji su izazvani nepolitićkim zloćinima ili djelima protivnima ciljevima i naćelima Ujedinjenih naroda.</para>
+<para>Na to se pravo ne može pozivati u slučaju progona koji su izazvani nepolitičkim zločinima ili djelima protivnima ciljevima i načelima Ujedinjenih naroda.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="15">
-<title>ĆLANAK 15.</title>
+<title>ČLANAK 15.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na drćavljanstvo.</para>
+<para>Svatko ima pravo na državljanstvo.</para>
 </listitem>
 <listitem>
-<para>Nitko ne smije samovoljno biti lišen svoga drćavljanstva niti mu se smije odreći pravo da promijeni svoje drćavljanstvo.</para>
+<para>Nitko ne smije samovoljno biti lišen svoga državljanstva niti mu se smije odreći pravo da promijeni svoje državljanstvo.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="16">
-<title>ĆLANAK 16.</title>
+<title>ČLANAK 16.</title>
 <orderedlist>
 <listitem>
-<para>Punoljetni muškarci i ćene, bez ikakvih ogranićenja u pogledu rase, drćavljanstva ili vjere, imaju pravo sklopiti brak i osnovati obitelj. Oni su ravnopravni prilikom sklapanja braka, za vrijeme njegova trajanja i prilikom njegova razvoda.</para>
+<para>Punoljetni muškarci i žene, bez ikakvih ograničenja u pogledu rase, državljanstva ili vjere, imaju pravo sklopiti brak i osnovati obitelj. Oni su ravnopravni prilikom sklapanja braka, za vrijeme njegova trajanja i prilikom njegova razvoda.</para>
 </listitem>
 <listitem>
 <para>Brak se sklapa samo uz slobodan i potpun pristanak onih koji namjeravaju stupiti u brak.</para>
 </listitem>
 <listitem>
-<para>Obitelj je prirodna i osnovna društvena jedinica i ima pravo na zaštitu društva i drćave.</para>
+<para>Obitelj je prirodna i osnovna društvena jedinica i ima pravo na zaštitu društva i države.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="17">
-<title>ĆLANAK 17.</title>
+<title>ČLANAK 17.</title>
 <orderedlist>
 <listitem>
 <para>Svatko ima pravo da sam posjeduje imovinu, a isto tako da je posjeduje u zajednici s drugima.</para>
@@ -132,53 +132,53 @@
 </orderedlist>
 </article>
 <article number="18">
-<title>ĆLANAK 18.</title>
-<para>Svatko ima pravo na slobodu misli, savjesti i vjere; to pravo ukljućuje slobodu da promijeni svoju vjeru ili vjerovanje i slobodu da, bilo pojedinaćno ili zajedno s drugima, javno ili privatno, oćituje vjeru ili vjerovanje ućenjem, praktićnim vršenjem, obredima i odrćavanjem.</para>
+<title>ČLANAK 18.</title>
+<para>Svatko ima pravo na slobodu misli, savjesti i vjere; to pravo uključuje slobodu da promijeni svoju vjeru ili vjerovanje i slobodu da, bilo pojedinačno ili zajedno s drugima, javno ili privatno, očituje vjeru ili vjerovanje učenjem, praktičnim vršenjem, obredima i održavanjem.</para>
 </article>
 <article number="19">
-<title>ĆLANAK 19.</title>
-<para>Svatko ima pravo na slobodu mišljenja i izraćavanja; ovo pravo ukljućuje slobodu mišljenja, bez tućeg miješanja, a isto tako i traćenje, primanje i priopćavanje obavijesti i ideja bilo kojim sredstvima i bez obzira na granice.</para>
+<title>ČLANAK 19.</title>
+<para>Svatko ima pravo na slobodu mišljenja i izražavanja; ovo pravo uključuje slobodu mišljenja, bez tuđeg miješanja, a isto tako i traženje, primanje i priopćavanje obavijesti i ideja bilo kojim sredstvima i bez obzira na granice.</para>
 </article>
 <article number="20">
-<title>ĆLANAK 20.</title>
+<title>ČLANAK 20.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na slobodu mirnog okupljanja i udrućivanja.</para>
+<para>Svatko ima pravo na slobodu mirnog okupljanja i udruživanja.</para>
 </listitem>
 <listitem>
-<para>Nitko ne moće biti primoran pripadati nekom udrućenju.</para>
+<para>Nitko ne može biti primoran pripadati nekom udruženju.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="21">
-<title>ĆLANAK 21.</title>
+<title>ČLANAK 21.</title>
 <orderedlist>
 <listitem>
 <para>Svatko ima pravo sudjelovati u upravi svoje zemlje, neposredno ili preko slobodno izabranih predstavnika.</para>
 </listitem>
 <listitem>
-<para>Svatko ima pravo na jednak pristup javnim slućbama u svojoj zemlji.</para>
+<para>Svatko ima pravo na jednak pristup javnim službama u svojoj zemlji.</para>
 </listitem>
 <listitem>
-<para>Volja naroda treba da bude osnova drćavne vlasti; ta se volja mora izraćavati povremenim i slobodnim izborima, uz opće i jednako pravo glasa, tajnim glasovanjem ili odgovarajućim postupcima slobodnog glasovanja.</para>
+<para>Volja naroda treba da bude osnova državne vlasti; ta se volja mora izražavati povremenim i slobodnim izborima, uz opće i jednako pravo glasa, tajnim glasovanjem ili odgovarajućim postupcima slobodnog glasovanja.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="22">
-<title>ĆLANAK 22.</title>
-<para>Svatko, kao ćlan društva, ima pravo na socijalno osiguranje i pravo ostvarivati gospodarska, socijalna i kulturna prava potrebna za svoje dostojanstvo i za razvoj svoje osobnosti putem drćavne pomoći i mećunarodne suradnje, a u skladu s organizacijom i sredstvima svake drćave.</para>
+<title>ČLANAK 22.</title>
+<para>Svatko, kao član društva, ima pravo na socijalno osiguranje i pravo ostvarivati gospodarska, socijalna i kulturna prava potrebna za svoje dostojanstvo i za razvoj svoje osobnosti putem državne pomoći i međunarodne suradnje, a u skladu s organizacijom i sredstvima svake države.</para>
 </article>
 <article number="23">
-<title>ĆLANAK 23.</title>
+<title>ČLANAK 23.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na rad, na slobodan izbor zaposlenja, na pravićne i povoljne uvjete rada i na zaštitu od nezaposlenosti.</para>
+<para>Svatko ima pravo na rad, na slobodan izbor zaposlenja, na pravične i povoljne uvjete rada i na zaštitu od nezaposlenosti.</para>
 </listitem>
 <listitem>
 <para>Svatko bez razlike ima pravo na jednaku plaću za jednaki rad.</para>
 </listitem>
 <listitem>
-<para>Svatko tko radi ima pravo na pravićnu i povoljnu plaću koja njemu i njegovoj obitelji osigurava ćovjeka dostojni opstanak i koja se, po potrebi, dopunjuje drugim sredstvima socijalne zaštite.</para>
+<para>Svatko tko radi ima pravo na pravičnu i povoljnu plaću koja njemu i njegovoj obitelji osigurava čovjeka dostojni opstanak i koja se, po potrebi, dopunjuje drugim sredstvima socijalne zaštite.</para>
 </listitem>
 <listitem>
 <para>Svatko ima pravo radi zaštite svojih interesa osnivati sindikate i stupati u njih.</para>
@@ -186,28 +186,28 @@
 </orderedlist>
 </article>
 <article number="24">
-<title>ĆLANAK 24.</title>
-<para>Svatko ima pravo na odmor i dokolicu, ukljućujući razumno ogranićenje radnih sati i periodićne plaćene dopuste.</para>
+<title>ČLANAK 24.</title>
+<para>Svatko ima pravo na odmor i dokolicu, uključujući razumno ograničenje radnih sati i periodične plaćene dopuste.</para>
 </article>
 <article number="25">
-<title>ĆLANAK 25.</title>
+<title>ČLANAK 25.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na ćivotni standard koji odgovara zdravlju i dobrobiti njega samoga i njegove obitelji, ukljućujući hranu, odjeću, stan i lijećnićku njegu, te potrebne socijalne usluge, kao i pravo na osiguranje u slućaju nezaposlenosti, bolesti, nesposobnosti, udovištva, starosti ili drugog pomanjkanja sredstava za ćivot u prilikama koje su izvan njegove moći.</para>
+<para>Svatko ima pravo na životni standard koji odgovara zdravlju i dobrobiti njega samoga i njegove obitelji, uključujući hranu, odjeću, stan i liječničku njegu, te potrebne socijalne usluge, kao i pravo na osiguranje u slučaju nezaposlenosti, bolesti, nesposobnosti, udovištva, starosti ili drugog pomanjkanja sredstava za život u prilikama koje su izvan njegove moći.</para>
 </listitem>
 <listitem>
-<para>Majka i dijete imaju pravo na posebnu skrb i pomoć. Sva djeca, roćena bilo u braku ili izvan njega, moraju ućivati istu socijalnu zaštitu.</para>
+<para>Majka i dijete imaju pravo na posebnu skrb i pomoć. Sva djeca, rođena bilo u braku ili izvan njega, moraju uživati istu socijalnu zaštitu.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="26">
-<title>ĆLANAK 26.</title>
+<title>ČLANAK 26.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo na obrazovanje. Obrazovanje mora biti besplatno, bar u osnovnim i nićim stupnjevima. Osnovno obrazovanje mora biti obvezatno. Tehnićko i strućno obrazovanje mora biti općenito pristupaćno,a više obrazovanje takoćer mora biti pristupaćno svima na osnovi sposobnosti.</para>
+<para>Svatko ima pravo na obrazovanje. Obrazovanje mora biti besplatno, bar u osnovnim i nižim stupnjevima. Osnovno obrazovanje mora biti obvezatno. Tehničko i stručno obrazovanje mora biti općenito pristupačno, a više obrazovanje također mora biti pristupačno svima na osnovi sposobnosti.</para>
 </listitem>
 <listitem>
-<para>Obrazovanje mora biti usmjereno punom razvitku ljudske osobe i na ućvršćenje poštovanja ćovjekovih prava i osnovnih sloboda. Ono mora unaprećivati razumijevanje, snošljivost i prijateljstvo meću svim narodima , rasnim i vjerskim skupinama i mora unaprećivati djelatnost Ujedinjenih naroda na odrćanju mira.</para>
+<para>Obrazovanje mora biti usmjereno punom razvitku ljudske osobe i na učvršćenje poštovanja čovjekovih prava i osnovnih sloboda. Ono mora unapređivati razumijevanje, snošljivost i prijateljstvo među svim narodima, rasnim i vjerskim skupinama i mora unapređivati djelatnost Ujedinjenih naroda na održanju mira.</para>
 </listitem>
 <listitem>
 <para>Roditelji imaju prvenstveno pravo birati vrstu obrazovanja za svoju djecu.</para>
@@ -215,36 +215,36 @@
 </orderedlist>
 </article>
 <article number="27">
-<title>ĆLANAK 27.</title>
+<title>ČLANAK 27.</title>
 <orderedlist>
 <listitem>
-<para>Svatko ima pravo slobodno sudjelovati u kulturnom ćivotu zajednice, ućivati u umjetnosti i sudjelovati u znanstvenom napretku i u njegovim koristima.</para>
+<para>Svatko ima pravo slobodno sudjelovati u kulturnom životu zajednice, uživati u umjetnosti i sudjelovati u znanstvenom napretku i u njegovim koristima.</para>
 </listitem>
 <listitem>
-<para>Svatko ima pravo na zaštitu moralnih i materijalnih interesa koji proistjeću od ma kojeg znanstvenog, knjićevnog ili umjetnićkog djela kojemu je autor.</para>
+<para>Svatko ima pravo na zaštitu moralnih i materijalnih interesa koji proistječu od ma kojeg znanstvenog, književnog ili umjetničkog djela kojemu je autor.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="28">
-<title>ĆLANAK 28.</title>
-<para>Svatko ima pravo na društveni i mećunarodni poredak u kojem prava i slobode navedeni u ovoj Deklaraciji mogu biti potpuno ostvareni.</para>
+<title>ČLANAK 28.</title>
+<para>Svatko ima pravo na društveni i međunarodni poredak u kojem prava i slobode navedeni u ovoj Deklaraciji mogu biti potpuno ostvareni.</para>
 </article>
 <article number="29">
-<title>ĆLANAK 29.</title>
+<title>ČLANAK 29.</title>
 <orderedlist>
 <listitem>
 <para>Svatko ima obveze prema zajednici iz koje je jedino moguće slobodno i puno razvijanje njegove osobnosti.</para>
 </listitem>
 <listitem>
-<para>U izvršavanju svojih prava i sloboda svatko mora biti podvrgnut samo ogranićenjima odrećenima zakonom iskljućivo radi osiguranja dućnog priznanja i poštovanja prava i sloboda drugih i radi zadovoljenja pravićnih zahtjeva morala, javnog poretka i općeg blagostanja u demokratskom društvu.</para>
+<para>U izvršavanju svojih prava i sloboda svatko mora biti podvrgnut samo ograničenjima određenima zakonom isključivo radi osiguranja dužnog priznanja i poštovanja prava i sloboda drugih i radi zadovoljenja pravičnih zahtjeva morala, javnog poretka i općeg blagostanja u demokratskom društvu.</para>
 </listitem>
 <listitem>
-<para>Ta prava i slobode ni u kojem se slućaju ne mogu primjenjivati protivno ciljevima i naćelima Ujedinjenih naroda.</para>
+<para>Ta prava i slobode ni u kojem se slučaju ne mogu primjenjivati protivno ciljevima i načelima Ujedinjenih naroda.</para>
 </listitem>
 </orderedlist>
 </article>
 <article number="30">
-<title>ĆLANAK 30.</title>
-<para>Ništa se u ovoj Deklaraciji ne moće tumaćiti kao pravo ma koje drćave, skupine ili osobe da sudjeluje bilo u kojoj djelatnosti ili da ćini bilo kakvu radnju usmjerenu uništenju bilo kojih ovdje navedenih prava i sloboda.</para>
+<title>ČLANAK 30.</title>
+<para>Ništa se u ovoj Deklaraciji ne može tumačiti kao pravo ma koje države, skupine ili osobe da sudjeluje bilo u kojoj djelatnosti ili da čini bilo kakvu radnju usmjerenu uništenju bilo kojih ovdje navedenih prava i sloboda.</para>
 </article>
 </udhr>


### PR DESCRIPTION
[Rosetta Type](https://github.com/rosettatype/) launched this [web app](https://universalspecimen.rosettatype.com/) to preview the UDHR in various languages and fonts. We got user feedback that the Croatian text (based on this repository) are containing errors, particular wrong accents (mostly zcaron U+017E / ccaron U+010D and their uppercase variants) and the transcribed dbar (U+0111) letters.

Looking at the OHCHR page the [Croatian translation](https://www.ohchr.org/EN/UDHR/Pages/Language.aspx?LangID=src2) appears to be a pixel PDF and the text extracted from that file with optical text recognition yields approximately the same false transcriptions. Our assumption was that this automatically extracted text has never been scrutinized for accuracy and those are automated text recognition errors.

We and the native language speaker reporting the error have gone through the text and corrected the transcript included in this PR.