### PR TITLE
udhr_yor: U+0323 instead of U+0329

### DIFF
--- a/data/udhr/udhr_yor.xml
+++ b/data/udhr/udhr_yor.xml
@@ -3,257 +3,257 @@
 <!--© The Office of the High Commisioner for Human Rights-->
 
 <!-- 
-replaced U+031F ◌̟ COMBINING PLUS SIGN BELOW by U+0329 ◌̩ COMBINING VERTICAL LINE BELOW
+replaced U+031F ◌̟ COMBINING PLUS SIGN BELOW by U+0323 ◌̣ COMBINING DOT BELOW
 replaced U+0305 ◌̅ COMBINING OVERLINE by U+0304 ◌̄ COMBINING MACRON
 replaced U+007C | VERTICAL LINE by U+0304 ◌̄ COMBINING MACRON
 replaced U+002D - HYPHEN-MINUS by U+2010 ‐ HYPHEN
 
-there is one occurrence of <U+0074 t LATIN SMALL LETTER T, U+0329 ◌̩ COMBINING VERTICAL LINE BELOW>
+there is one occurrence of <U+0074 t LATIN SMALL LETTER T, U+0323 ◌̣ COMBINING DOT BELOW>
 which should probably be a simple <t>.
 -->
    
 <udhr iso639-3='yor' xml:lang='yo' key='yor' n='Yoruba' dir='ltr' iso15924='Latn' xmlns="http://www.unicode.org/udhr">
-  <title>ÌKÉDE KÁRÍAYÉ FÚN È̩TÓ̩ O̩MO̩NÌYÀN</title>
+  <title>ÌKÉDE KÁRÍAYÉ FÚN Ẹ̀TỌ́ ỌMỌNÌYÀN</title>
   <preamble>
-    <title>Ò̩RÒ̩ ÀKÓ̩SO̩</title>
-    <para>Bí ó ti jé̩ pé s̩ís̩e àkíyèsí iyì tó jé̩ àbímó̩ fún è̩dá àti ìdó̩gba è̩tó̩ t̩í kò s̩eé mú kúrò tí è̩dá kò̩ò̩kan ní, ni òkúta ìpìlè̩ fún òmìnira, ìdájó̩ òdodo àti àlàáfíà lágbàáyé,</para>
-    <para>Bí ó ti jé̩ pé àìka àwo̩n è̩tó̩ o̩mo̩nìyàn sí àti ìké̩gàn àwo̩n è̩tó̩ wò̩nyí ti s̩e okùnfà fún àwo̩n ìwà búburú kan, tó mú è̩rí‐o̩kàn è̩dá gbo̩gbé̩, tó sì jé̩ pé ìbè̩rè̩ ìgbé ayé titun, nínú èyí tí àwo̩n ènìyàn yóò ti ní òmìnira òrò̩ síso̩ àti òmìnira láti gba ohun tó bá wù wó̩n gbó̩, òmìnira ló̩wó̩ è̩rù àti òmìnira ló̩wó̩ àìní, ni a ti kà sí àníyàn tó ga jù lo̩ ló̩kàn àwo̩n o̩mo̩‐èniyàn,</para>
-    <para>Bí ó ti jé̩ pé ó s̩e pàtàkì kí a dáàbò bo àwo̩n è̩tó o̩mo̩nìyàn lábé̩ òfin, bí a kò bá fé̩ ti àwo̩n ènìyàn láti ko̩jú ìjà sí ìjo̩ba ipá àti ti amúnisìn, nígbà tí kò bá sí ò̩nà àbáyo̩ mìíràn fún wo̩n láti bèèrè è̩tó̩ wo̩n,</para>
-    <para>Bí ó ti jé̩ pé ó s̩e pàtàkì kí ìdàgbàsókè ìbás̩epò̩ ti ò̩ré̩‐sí‐ò̩ré̩ wà láàrin àwo̩n orílè̩‐èdè,</para>
-    <para>Bí ó ti jé̩ pé gbogbo o̩mo̩ Àjo̩‐ìsò̩kan orílè̩‐èdè àgbáyé tún ti te̩nu mó̩ ìpinnu tí wó̩n ti s̩e té̩lè̩ nínú ìwé àdéhùn wo̩n, pé àwo̩n ní ìgbàgbó̩ nínú è̩tó̩ o̩mo̩nìyàn tó jé̩ kò‐s̩eé‐má‐nìí, ìgbàgbó̩ nínú iyì àti è̩ye̩ è̩dá ènìyàn, àti ìgbàgbó̩ nínú ìdó̩gba è̩tó̩ láàrin o̩kùnrin àti obìnrin, tó sì jé̩ pé wó̩n tún ti pinnu láti s̩e ìgbéláruge̩ ìtè̩síwájú àwùjo̩ nínú èyí tí òmìnira ètò ìgbé‐ayé rere è̩dá ti lè gbòòrò sí i,</para>
-    <para>Bí ó ti jé̩ pé àwo̩n o̩mo̩ e̩gbé̩ Àjo̩‐ìsò̩kan orílè̩‐èdè àgbáyé ti jé̩jè̩é̩ láti fo̩wó̩s̩owó̩ pò̩ pè̩lú Àjo̩ náà, kí won lè jo̩ s̩e às̩eyege nípa àmús̩e̩ àwo̩n è̩tó̩ o̩mo̩nìyàn àti òmìnira è̩dá tó jé̩ kò‐s̩eé‐má‐nìí àti láti rí i pé à ń bò̩wò̩ fún àwo̩n è̩tó̩ náà káríayé,</para>
-    <para>Bí ó ti jé̩ pé àfi tí àwo̩n è̩tó̩ àti òmìnira wò̩nyí bá yé ènìyàn nìkan ni a fi lè ní àmús̩e̩ è̩jé̩ yìí ní kíkún,</para>
+    <title>Ọ̀RỌ̀ ÀKỌ́SỌ</title>
+    <para>Bí ó ti jẹ́ pé ṣíṣe àkíyèsí iyì tó jẹ́ àbímọ́ fún ẹ̀dá àti ìdọ́gba ẹ̀tọ́ ṭí kò ṣeé mú kúrò tí ẹ̀dá kọ̀ọ̀kan ní, ni òkúta ìpìlẹ̀ fún òmìnira, ìdájọ́ òdodo àti àlàáfíà lágbàáyé,</para>
+    <para>Bí ó ti jẹ́ pé àìka àwọn ẹ̀tọ́ ọmọnìyàn sí àti ìkẹ́gàn àwọn ẹ̀tọ́ wọ̀nyí ti ṣe okùnfà fún àwọn ìwà búburú kan, tó mú ẹ̀rí‐ọkàn ẹ̀dá gbọgbẹ́, tó sì jẹ́ pé ìbẹ̀rẹ̀ ìgbé ayé titun, nínú èyí tí àwọn ènìyàn yóò ti ní òmìnira òrọ̀ sísọ àti òmìnira láti gba ohun tó bá wù wọ́n gbọ́, òmìnira lọ́wọ́ ẹ̀rù àti òmìnira lọ́wọ́ àìní, ni a ti kà sí àníyàn tó ga jù lọ lọ́kàn àwọn ọmọ‐èniyàn,</para>
+    <para>Bí ó ti jẹ́ pé ó ṣe pàtàkì kí a dáàbò bo àwọn ẹ̀tó ọmọnìyàn lábẹ́ òfin, bí a kò bá fẹ́ ti àwọn ènìyàn láti kọjú ìjà sí ìjọba ipá àti ti amúnisìn, nígbà tí kò bá sí ọ̀nà àbáyọ mìíràn fún wọn láti bèèrè ẹ̀tọ́ wọn,</para>
+    <para>Bí ó ti jẹ́ pé ó ṣe pàtàkì kí ìdàgbàsókè ìbáṣepọ̀ ti ọ̀rẹ́‐sí‐ọ̀rẹ́ wà láàrin àwọn orílẹ̀‐èdè,</para>
+    <para>Bí ó ti jẹ́ pé gbogbo ọmọ Àjọ‐ìsọ̀kan orílẹ̀‐èdè àgbáyé tún ti tẹnu mọ́ ìpinnu tí wọ́n ti ṣe tẹ́lẹ̀ nínú ìwé àdéhùn wọn, pé àwọn ní ìgbàgbọ́ nínú ẹ̀tọ́ ọmọnìyàn tó jẹ́ kò‐ṣeé‐má‐nìí, ìgbàgbọ́ nínú iyì àti ẹ̀yẹ ẹ̀dá ènìyàn, àti ìgbàgbọ́ nínú ìdọ́gba ẹ̀tọ́ láàrin ọkùnrin àti obìnrin, tó sì jẹ́ pé wọ́n tún ti pinnu láti ṣe ìgbélárugẹ ìtẹ̀síwájú àwùjọ nínú èyí tí òmìnira ètò ìgbé‐ayé rere ẹ̀dá ti lè gbòòrò sí i,</para>
+    <para>Bí ó ti jẹ́ pé àwọn ọmọ ẹgbẹ́ Àjọ‐ìsọ̀kan orílẹ̀‐èdè àgbáyé ti jẹ́jẹ̀ẹ́ láti fọwọ́ṣowọ́ pọ̀ pẹ̀lú Àjọ náà, kí won lè jọ ṣe àṣeyege nípa àmúṣẹ àwọn ẹ̀tọ́ ọmọnìyàn àti òmìnira ẹ̀dá tó jẹ́ kò‐ṣeé‐má‐nìí àti láti rí i pé à ń bọ̀wọ̀ fún àwọn ẹ̀tọ́ náà káríayé,</para>
+    <para>Bí ó ti jẹ́ pé àfi tí àwọn ẹ̀tọ́ àti òmìnira wọ̀nyí bá yé ènìyàn nìkan ni a fi lè ní àmúṣẹ ẹ̀jẹ́ yìí ní kíkún,</para>
     <para>Ní báyìí,</para>
-    <para>Àpapò̩ ìgbìmò̩ Àjo̩‐ìsò̩kan orílè̩‐èdè àgbáyé s̩e ìkéde káríayé ti è̩tó̩ o̩mo̩nìyàn, gé̩gé̩ bí ohun àfojúsùn tí gbogbo è̩dá àti orílè̩‐èdè jo̩ ń lépa ló̩nà tó jé̩ pé e̩nì kò̩ò̩kan àti è̩ka kò̩ò̩kan láwùjo̩ yóò fi ìkéde yìí só̩kàn, tí wo̩n yóò sì rí i pé àwo̩n lo ètò‐ìkó̩ni àti ètò‐è̩kó̩ láti s̩e ìgbéláruge̩ ìbò̩wò̩ fún è̩tó̩ àti òmìnira wò̩nyí. Bákan náà, a gbo̩dò̩ rí àwo̩n ìgbésè̩ tí ó lè mú ìlo̩síwájú bá orílè̩‐èdè kan s̩os̩o tàbí àwo̩n orílè̩‐èdè sí ara wo̩n, kí a sì rí i pé a fi ò̩wò̩ tó jo̩jú wo̩ àwo̩n òfin wò̩nyí, kí àmúlò wo̩n sì jé̩ káríayé láàrin àwo̩n ènìyàn orílè̩‐èdè tó jé̩ o̩mo̩ Àjo̩‐ìsò̩kan àgbáyé fúnra wo̩n àti láàrin àwo̩n ènìyàn orílè̩‐èdè mìíràn tó wà lábé̩ às̩e̩ wo̩n.</para>
+    <para>Àpapọ̀ ìgbìmọ̀ Àjọ‐ìsọ̀kan orílẹ̀‐èdè àgbáyé ṣe ìkéde káríayé ti ẹ̀tọ́ ọmọnìyàn, gẹ́gẹ́ bí ohun àfojúsùn tí gbogbo ẹ̀dá àti orílẹ̀‐èdè jọ ń lépa lọ́nà tó jẹ́ pé ẹnì kọ̀ọ̀kan àti ẹ̀ka kọ̀ọ̀kan láwùjọ yóò fi ìkéde yìí sọ́kàn, tí wọn yóò sì rí i pé àwọn lo ètò‐ìkọ́ni àti ètò‐ẹ̀kọ́ láti ṣe ìgbélárugẹ ìbọ̀wọ̀ fún ẹ̀tọ́ àti òmìnira wọ̀nyí. Bákan náà, a gbọdọ̀ rí àwọn ìgbésẹ̀ tí ó lè mú ìlọsíwájú bá orílẹ̀‐èdè kan ṣoṣo tàbí àwọn orílẹ̀‐èdè sí ara wọn, kí a sì rí i pé a fi ọ̀wọ̀ tó jọjú wọ àwọn òfin wọ̀nyí, kí àmúlò wọn sì jẹ́ káríayé láàrin àwọn ènìyàn orílẹ̀‐èdè tó jẹ́ ọmọ Àjọ‐ìsọ̀kan àgbáyé fúnra wọn àti láàrin àwọn ènìyàn orílẹ̀‐èdè mìíràn tó wà lábẹ́ àṣẹ wọn.</para>
   </preamble>
   <article number="1">
     <title>Abala kìíní.</title>
-    <para>Gbogbo ènìyàn ni a bí ní òmìnira; iyì àti è̩tó̩ kò̩ò̩kan sì dó̩gba. Wó̩n ní è̩bùn ti làákàyè àti ti è̩rí‐o̩kàn, ó sì ye̩ kí wo̩n ó máa hùwà sí ara wo̩n gé̩gé̩ bí o̩mo̩ ìyá.</para>
+    <para>Gbogbo ènìyàn ni a bí ní òmìnira; iyì àti ẹ̀tọ́ kọ̀ọ̀kan sì dọ́gba. Wọ́n ní ẹ̀bùn ti làákàyè àti ti ẹ̀rí‐ọkàn, ó sì yẹ kí wọn ó máa hùwà sí ara wọn gẹ́gẹ́ bí ọmọ ìyá.</para>
   </article>
   <article number="2">
     <title>Abala kejì.</title>
-    <para>E̩nì kò̩ò̩kan ló ní ànfàní sí gbogbo è̩tó̩ àti òmìnira tí a ti gbé kalè̩ nínú ìkéde yìí láìfi ti ò̩rò̩ ìyàtò̩ è̩yà kankan s̩e; ìyàtò̩ bí i ti è̩yà ènìyàn, àwò̩, ako̩‐n̄‐bábo, èdè, è̩sìn, ètò ìs̩èlú tàbí ìyàtò̩ nípa èrò e̩ni, orílè̩‐èdè e̩ni, orírun e̩ni, ohun ìní e̩ni, ìbí e̩ni tàbí ìyàtò̩ mìíràn yòówù kó jé̩. Síwájú sí i, a kò gbo̩dò̩ ya e̩nìké̩ni só̩tò̩ nítorí irú ìjo̩ba orílè̩‐èdè rè̩ ní àwùjo̩ àwo̩n orílè̩‐èdè tàbí nítorí ètò‐ìs̩èlú tàbí ètò‐ìdájó̩ orílè̩‐èdè rè̩; orílè̩‐èdè náà ìbáà wà ní òmìnira tàbí kí ó wà lábé̩ ìs̩àkóso ilè̩ mìíràn, wo̩n ìbáà má dàá ìjo̩ba ara wo̩n s̩e tàbí kí wó̩n wà lábé̩ ìkáni‐lápá‐kò yòówù tí ìbáà fé̩ dí òmìnira wo̩n ló̩wó̩ gé̩gé̩ bí orílè̩‐èdè.</para>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ànfàní sí gbogbo ẹ̀tọ́ àti òmìnira tí a ti gbé kalẹ̀ nínú ìkéde yìí láìfi ti ọ̀rọ̀ ìyàtọ̀ ẹ̀yà kankan ṣe; ìyàtọ̀ bí i ti ẹ̀yà ènìyàn, àwọ̀, akọ‐n̄‐bábo, èdè, ẹ̀sìn, ètò ìṣèlú tàbí ìyàtọ̀ nípa èrò ẹni, orílẹ̀‐èdè ẹni, orírun ẹni, ohun ìní ẹni, ìbí ẹni tàbí ìyàtọ̀ mìíràn yòówù kó jẹ́. Síwájú sí i, a kò gbọdọ̀ ya ẹnìkẹ́ni sọ́tọ̀ nítorí irú ìjọba orílẹ̀‐èdè rẹ̀ ní àwùjọ àwọn orílẹ̀‐èdè tàbí nítorí ètò‐ìṣèlú tàbí ètò‐ìdájọ́ orílẹ̀‐èdè rẹ̀; orílẹ̀‐èdè náà ìbáà wà ní òmìnira tàbí kí ó wà lábẹ́ ìṣàkóso ilẹ̀ mìíràn, wọn ìbáà má dàá ìjọba ara wọn ṣe tàbí kí wọ́n wà lábẹ́ ìkáni‐lápá‐kò yòówù tí ìbáà fẹ́ dí òmìnira wọn lọ́wọ́ gẹ́gẹ́ bí orílẹ̀‐èdè.</para>
     <para/>
   </article>
   <article number="3">
-    <title>Abala ke̩ta.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti wà láàyè, è̩tó̩ sí òmìnira àti è̩tó̩ sí ààbò ara rè̩.</para>
+    <title>Abala kẹta.</title>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti wà láàyè, ẹ̀tọ́ sí òmìnira àti ẹ̀tọ́ sí ààbò ara rẹ̀.</para>
   </article>
   <article number="4">
-    <title>Abala ke̩rin.</title>
-    <para>A kò gbo̩dò̩ mú e̩niké̩ni ní e̩rú tàbí kí a mú un sìn; e̩rú níní àti ò wò e̩rú ni a gbo̩dò̩ fi òfin dè ní gbogbo ò̩nà.</para>
+    <title>Abala kẹrin.</title>
+    <para>A kò gbọdọ̀ mú ẹnikẹ́ni ní ẹrú tàbí kí a mú un sìn; ẹrú níní àti ò wò ẹrú ni a gbọdọ̀ fi òfin dè ní gbogbo ọ̀nà.</para>
   </article>
   <article number="5">
     <title>Abala karùn‐ún.</title>
-    <para>A kò gbo̩dò̩ dá e̩nì ké̩ni lóró tàbí kí a lò ó ní ìlò ìkà tí kò ye̩ o̩mo̩ ènìyàn tàbí ìlò tó lè tàbùkù è̩dá ènìyàn.</para>
+    <para>A kò gbọdọ̀ dá ẹnì kẹ́ni lóró tàbí kí a lò ó ní ìlò ìkà tí kò yẹ ọmọ ènìyàn tàbí ìlò tó lè tàbùkù ẹ̀dá ènìyàn.</para>
   </article>
   <article number="6">
-    <title>Abala ke̩fà.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ pé kí a kà á sí gé̩gé̩ bí ènìyàn lábé̩ òfin ní ibi gbogbo.</para>
+    <title>Abala kẹfà.</title>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ pé kí a kà á sí gẹ́gẹ́ bí ènìyàn lábẹ́ òfin ní ibi gbogbo.</para>
   </article>
   <article number="7">
     <title>Abala keje.</title>
-    <para>Gbogbo ènìyàn ló dó̩gba lábé̩ òfin. Wó̩n sì ní è̩tó̩ sí àà bò lábé̩ òfin láìsí ìyàsó̩tò̩ kankan. Gbogbo ènìyàn ló ní è̩tó̩ sí ààbò tó dó̩gba kúrò ló̩wó̩ ìyàsó̩tò̩ yòówù tí ìbáà lòdì sí ìkéde yìí àti è̩tó̩ kúrò ló̩wó̩ gbogbo ohun tó bá lè ti ènìyàn láti s̩e irú ìyàsó̩tò̩ bé̩è̩.</para>
+    <para>Gbogbo ènìyàn ló dọ́gba lábẹ́ òfin. Wọ́n sì ní ẹ̀tọ́ sí àà bò lábẹ́ òfin láìsí ìyàsọ́tọ̀ kankan. Gbogbo ènìyàn ló ní ẹ̀tọ́ sí ààbò tó dọ́gba kúrò lọ́wọ́ ìyàsọ́tọ̀ yòówù tí ìbáà lòdì sí ìkéde yìí àti ẹ̀tọ́ kúrò lọ́wọ́ gbogbo ohun tó bá lè ti ènìyàn láti ṣe irú ìyàsọ́tọ̀ bẹ́ẹ̀.</para>
   </article>
   <article number="8">
-    <title>Abala ke̩jo̩.</title>
-    <para>E̩nì kò̩ò̩kan lórílè̩‐èdè, ló ní è̩tó̩ sí àtúns̩e tó jo̩jú ní ilé‐e̩jó̩ fún ìwà tó lòdì sí è̩tó̩ o̩mo̩nìyàn, tó jé̩ kò‐s̩eé‐má‐nìí gé̩gé̩ bó s̩e wà lábé̩ òfin àti bí òfin‐ìpìlè̩ s̩e là á sílè̩.</para>
+    <title>Abala kẹjọ.</title>
+    <para>Ẹnì kọ̀ọ̀kan lórílẹ̀‐èdè, ló ní ẹ̀tọ́ sí àtúnṣe tó jọjú ní ilé‐ẹjọ́ fún ìwà tó lòdì sí ẹ̀tọ́ ọmọnìyàn, tó jẹ́ kò‐ṣeé‐má‐nìí gẹ́gẹ́ bó ṣe wà lábẹ́ òfin àti bí òfin‐ìpìlẹ̀ ṣe là á sílẹ̀.</para>
   </article>
   <article number="9">
-    <title>Abala ke̩sàn‐án.</title>
-    <para>A kò gbo̩dò̩ s̩àdédé fi òfin mú ènìyàn tàbí kí a kàn gbé ènìyàn tì mó̩lé, tàbí kí a lé ènìyàn jáde ní ìlú láìnídìí.</para>
+    <title>Abala kẹsàn‐án.</title>
+    <para>A kò gbọdọ̀ ṣàdédé fi òfin mú ènìyàn tàbí kí a kàn gbé ènìyàn tì mọ́lé, tàbí kí a lé ènìyàn jáde ní ìlú láìnídìí.</para>
   </article>
   <article number="10">
-    <title>Abala ke̩wàá.</title>
-    <para>E̩nì kò̩ò̩kan tí a bá fi è̩sùn kàn ló ní è̩tó̩ tó dó̩gba, tó sì kún, láti s̩àlàyé ara rè̩ ní gban̄gba, níwájú ilé‐e̩jó̩ tí kò s̩ègbè, kí wo̩n lè s̩e ìpinnu lórí è̩tó̩ àti ojús̩e rè̩ nípa irú è̩sùn ò̩ràn dídá tí a fi kàn án.</para>
+    <title>Abala kẹwàá.</title>
+    <para>Ẹnì kọ̀ọ̀kan tí a bá fi ẹ̀sùn kàn ló ní ẹ̀tọ́ tó dọ́gba, tó sì kún, láti ṣàlàyé ara rẹ̀ ní gban̄gba, níwájú ilé‐ẹjọ́ tí kò ṣègbè, kí wọn lè ṣe ìpinnu lórí ẹ̀tọ́ àti ojúṣe rẹ̀ nípa irú ẹ̀sùn ọ̀ràn dídá tí a fi kàn án.</para>
   </article>
   <article number="11">
-    <title>Abala ko̩kànlá.</title>
+    <title>Abala kọkànlá.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nìké̩ni tí a fi è̩sùn kàn ni a gbo̩dò̩ gbà wí pé ó jàrè títí è̩bi rè̩ yóò fi hàn lábé̩ òfin nípasè̩ ìdájó̩ tí a s̩e ní gban̄gba nínú èyí tí e̩ni tí a fi è̩sùn kàn yóò ti ní gbogbo ohun tí ó nílò láti fi s̩e àwíjàre ara rè̩.</para>
+	<para>Ẹnìkẹ́ni tí a fi ẹ̀sùn kàn ni a gbọdọ̀ gbà wí pé ó jàrè títí ẹ̀bi rẹ̀ yóò fi hàn lábẹ́ òfin nípasẹ̀ ìdájọ́ tí a ṣe ní gban̄gba nínú èyí tí ẹni tí a fi ẹ̀sùn kàn yóò ti ní gbogbo ohun tí ó nílò láti fi ṣe àwíjàre ara rẹ̀.</para>
       </listitem>
       <listitem>
-	<para>A kò gbo̩dò̩ dá è̩bi è̩s̩è̩ fún e̩nìké̩ni fún pé ó hu ìwà kan tàbí pé ó s̩e àwo̩n àfojúfò kàn nígbà tó jé̩ pé lásìkò tí èyí s̩e̩lè̩, irú ìwà bé̩è̩ tàbí irú àfojúfò bé̩è̩ kò lòdì sí òfin orílè̩‐èdè e̩ni náà tàbí òfin àwo̩n orílè̩‐èdè àgbáyé mìíràn. Bákan náà, ìje̩níyà tí a lè fún e̩ni tó dé̩s̩è̩ kò gbo̩dò̩ ju èyí tó wà ní ìmúlò ní àsìkò tí e̩ni náà dá è̩s̩è̩ rè̩.</para>
+	<para>A kò gbọdọ̀ dá ẹ̀bi ẹ̀ṣẹ̀ fún ẹnìkẹ́ni fún pé ó hu ìwà kan tàbí pé ó ṣe àwọn àfojúfò kàn nígbà tó jẹ́ pé lásìkò tí èyí ṣẹlẹ̀, irú ìwà bẹ́ẹ̀ tàbí irú àfojúfò bẹ́ẹ̀ kò lòdì sí òfin orílẹ̀‐èdè ẹni náà tàbí òfin àwọn orílẹ̀‐èdè àgbáyé mìíràn. Bákan náà, ìjẹníyà tí a lè fún ẹni tó dẹ́ṣẹ̀ kò gbọdọ̀ ju èyí tó wà ní ìmúlò ní àsìkò tí ẹni náà dá ẹ̀ṣẹ̀ rẹ̀.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="12">
     <title>Abala kejìlá.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ pé kí a má s̩àdédé s̩e àyo̩júràn sí ò̩rò̩ ìgbésí ayé rè̩, tàbí sí ò̩rò̩e̩bí rè̩ tàbí sí ò̩rò̩ ìdílé rè̩ tàbí ìwé tí a ko̩ sí i; a kò sì gbo̩dò̩ ba iyì àti orúko̩ rè̩ jé̩. E̩nì kò̩ò̩kan ló ní è̩tó̩ sí ààbò lábé̩ òfin kúrò ló̩wó̩ irú àyo̩júràn tàbí ìbanijé̩ bé̩è̩.</para>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ pé kí a má ṣàdédé ṣe àyọjúràn sí ọ̀rọ̀ ìgbésí ayé rẹ̀, tàbí sí ọ̀rọ̀ẹbí rẹ̀ tàbí sí ọ̀rọ̀ ìdílé rẹ̀ tàbí ìwé tí a kọ sí i; a kò sì gbọdọ̀ ba iyì àti orúkọ rẹ̀ jẹ́. Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí ààbò lábẹ́ òfin kúrò lọ́wọ́ irú àyọjúràn tàbí ìbanijẹ́ bẹ́ẹ̀.</para>
   </article>
   <article number="13">
-    <title>Abala ke̩tàlá.</title>
+    <title>Abala kẹtàlá.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti rìn káàkiri ní òmìnira kí ó sì fi ibi tó bá wù ú s̩e ìbùgbé láàrin orílè̩‐èdè rè̩.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti rìn káàkiri ní òmìnira kí ó sì fi ibi tó bá wù ú ṣe ìbùgbé láàrin orílẹ̀‐èdè rẹ̀.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti kúrò lórílè̩‐èdè yòówù kó jé̩, tó fi mó̩ orílè̩‐èdè tirè̩, kí ó sì tún padà sí orílè̩‐èdè tirè̩ nígbà tó bá wù ú.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti kúrò lórílẹ̀‐èdè yòówù kó jẹ́, tó fi mọ́ orílẹ̀‐èdè tirẹ̀, kí ó sì tún padà sí orílẹ̀‐èdè tirẹ̀ nígbà tó bá wù ú.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="14">
-    <title>Abala ke̩rìnlá.</title>
+    <title>Abala kẹrìnlá.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti wá ààbò àti láti je̩ àn fàní ààbò yìí ní orílè̩‐èdè mìíràn nígbà tí a bá ń s̩e inúnibíni sí i.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti wá ààbò àti láti jẹ àn fàní ààbò yìí ní orílẹ̀‐èdè mìíràn nígbà tí a bá ń ṣe inúnibíni sí i.</para>
       </listitem>
       <listitem>
-	<para>A kò lè lo è̩tó̩ yìí fún e̩ni tí a bá pè lé̩jó̩ tó dájú nítorí e̩ s̩è̩ tí kò je̩ mó̩ ò̩rò̩ ìs̩èlú tàbí ohun mìíràn tí ó s̩e tí kò bá ète àti ìgbékalè̩ Ajo̩‐ìsò̩kan orílè̩‐èdè àgbáyé mu.</para>
+	<para>A kò lè lo ẹ̀tọ́ yìí fún ẹni tí a bá pè lẹ́jọ́ tó dájú nítorí ẹ ṣẹ̀ tí kò jẹ mọ́ ọ̀rọ̀ ìṣèlú tàbí ohun mìíràn tí ó ṣe tí kò bá ète àti ìgbékalẹ̀ Ajọ‐ìsọ̀kan orílẹ̀‐èdè àgbáyé mu.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="15">
-    <title>Abala ke̩è̩é̩dógún.</title>
+    <title>Abala kẹẹ̀ẹ́dógún.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti jé̩ o̩mo̩ orílè̩‐èdè kan.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti jẹ́ ọmọ orílẹ̀‐èdè kan.</para>
       </listitem>
       <listitem>
-	<para>A kò lè s̩àdédé gba è̩tó̩ jíjé̩ o̩mo̩ orílè̩‐èdè e̩ni ló̩wó̩ e̩nìké̩ni láìnídìí tàbí kí a kò̩ fún e̩nìké̩ni láti yàn láti jé̩ o̩mo̩ orílè̩‐èdè mìíràn.</para>
+	<para>A kò lè ṣàdédé gba ẹ̀tọ́ jíjẹ́ ọmọ orílẹ̀‐èdè ẹni lọ́wọ́ ẹnìkẹ́ni láìnídìí tàbí kí a kọ̀ fún ẹnìkẹ́ni láti yàn láti jẹ́ ọmọ orílẹ̀‐èdè mìíràn.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="16">
-    <title>Abala ke̩rìndínlógún.</title>
+    <title>Abala kẹrìndínlógún.</title>
     <orderedlist>
       <listitem>
-	<para>To̩kùnrin tobìnrin tó bá ti bàlágà ló ní è̩tó̩ láti fé̩ ara wo̩n, kí wó̩n sì dá e̩bí ti wo̩n sílè̩ láìsí ìkanilápá‐kò kankan nípa è̩yà wo̩n, tàbí orílè̩‐èdè wo̩n tàbí è̩sìn wo̩n. E̩tó̩ wo̩n dó̩gba nínú ìgbeyàwó ìbáà jé̩ nígbà tí wo̩n wà papò̩ tàbí lé̩yìn tí wó̩n bá ko̩ ara wo̩n.</para>
+	<para>Tọkùnrin tobìnrin tó bá ti bàlágà ló ní ẹ̀tọ́ láti fẹ́ ara wọn, kí wọ́n sì dá ẹbí ti wọn sílẹ̀ láìsí ìkanilápá‐kò kankan nípa ẹ̀yà wọn, tàbí orílẹ̀‐èdè wọn tàbí ẹ̀sìn wọn. Ẹtọ́ wọn dọ́gba nínú ìgbeyàwó ìbáà jẹ́ nígbà tí wọn wà papọ̀ tàbí lẹ́yìn tí wọ́n bá kọ ara wọn.</para>
       </listitem>
       <listitem>
-	<para>A kò gbo̩dò̩ s̩e ìgbeyàwó kan láìjé̩ pé àwo̩n tí ó fé̩ fé̩ ara wo̩n ní òmìnira àto̩kànwá tó péye láti yàn fúnra wo̩n.</para>
+	<para>A kò gbọdọ̀ ṣe ìgbeyàwó kan láìjẹ́ pé àwọn tí ó fẹ́ fẹ́ ara wọn ní òmìnira àtọkànwá tó péye láti yàn fúnra wọn.</para>
       </listitem>
       <listitem>
-	<para>E̩bí jé̩ ìpìlè̩ pàtàkì àdánidá ní àwùjo̩, ó sì ní è̩tó̩ pé kí àwùjo̩ àti orílè̩‐èdè ó dáàbò bò ó.</para>
+	<para>Ẹbí jẹ́ ìpìlẹ̀ pàtàkì àdánidá ní àwùjọ, ó sì ní ẹ̀tọ́ pé kí àwùjọ àti orílẹ̀‐èdè ó dáàbò bò ó.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="17">
-    <title>Abala ke̩tàdínlógún.</title>
+    <title>Abala kẹtàdínlógún.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti dá ohun ìní ara rè̩ ní tàbí láti ní in papò̩ pè̩lú àwo̩n mìíràn.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti dá ohun ìní ara rẹ̀ ní tàbí láti ní in papọ̀ pẹ̀lú àwọn mìíràn.</para>
       </listitem>
       <listitem>
-	<para>A kò lè s̩àdédé gba ohun ìní e̩nì kan ló̩wó̩ rè̩ láìnídìí.</para>
+	<para>A kò lè ṣàdédé gba ohun ìní ẹnì kan lọ́wọ́ rẹ̀ láìnídìí.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="18">
     <title>Abala kejìdínlógún.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí òmìnira èrò, òmìnira è̩rí‐o̩kàn àti òmìnira e̩ sìn. E̩tó̩ yìí sì gbani láàyè láti pààrò̩ e̩ sìn tàbí ìgbàgbó̩ e̩ni. Ó sì fún e̩yo̩ e̩nì kan tàbí àkójo̩pò̩ ènìyàn láàyè láti s̩e è̩sìn wo̩n àti ìgbàgbó̩ wo̩n bó s̩e je̩ mó̩ ti ìkó̩ni, ìs̩esí, ìjó̩sìn àti ìmús̩e ohun tí wó̩n gbàgbó̩ yálà ní ìkò̩kò̩ tàbí ní gban̄gba.</para>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí òmìnira èrò, òmìnira ẹ̀rí‐ọkàn àti òmìnira ẹ sìn. Ẹtọ́ yìí sì gbani láàyè láti pààrọ̀ ẹ sìn tàbí ìgbàgbọ́ ẹni. Ó sì fún ẹyọ ẹnì kan tàbí àkójọpọ̀ ènìyàn láàyè láti ṣe ẹ̀sìn wọn àti ìgbàgbọ́ wọn bó ṣe jẹ mọ́ ti ìkọ́ni, ìṣesí, ìjọ́sìn àti ìmúṣe ohun tí wọ́n gbàgbọ́ yálà ní ìkọ̀kọ̀ tàbí ní gban̄gba.</para>
   </article>
   <article number="19">
-    <title>Abala ko̩kàndínlógún.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí òmì nira láti ní ìmò̩ràn tí ó wù ú, kí ó sì so̩ irú ìmò̩ràn bé̩è̩ jáde; è̩tó̩yìí gbani láàyè láti ní ìmò̩ràn yòówù láìsí àtakò láti ò̩dò̩ e̩nìké̩ni láti wádìí ò̩rò̩, láti gba ìmò̩ràn ló̩dò̩ e̩lòmíràn tàbí láti gbani níyànjú ló̩nàkó̩nà láìka ààlà orílè̩‐èdè kankan kún.</para>
+    <title>Abala kọkàndínlógún.</title>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí òmì nira láti ní ìmọ̀ràn tí ó wù ú, kí ó sì sọ irú ìmọ̀ràn bẹ́ẹ̀ jáde; ẹ̀tọ́yìí gbani láàyè láti ní ìmọ̀ràn yòówù láìsí àtakò láti ọ̀dọ̀ ẹnìkẹ́ni láti wádìí ọ̀rọ̀, láti gba ìmọ̀ràn lọ́dọ̀ ẹlòmíràn tàbí láti gbani níyànjú lọ́nàkọ́nà láìka ààlà orílẹ̀‐èdè kankan kún.</para>
   </article>
   <article number="20">
     <title>Abala ogún.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí òmìnira láti pé jo̩ pò̩ àti láti dara pò̩ mó̩ àwo̩n mìíràn ní àlàáfíà.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí òmìnira láti pé jọ pọ̀ àti láti dara pọ̀ mọ́ àwọn mìíràn ní àlàáfíà.</para>
       </listitem>
       <listitem>
-	<para>A kò lè fi ipá mú e̩nìké̩ni dara pò̩ mó̩ e̩gbé̩ kankan.</para>
+	<para>A kò lè fi ipá mú ẹnìkẹ́ni dara pọ̀ mọ́ ẹgbẹ́ kankan.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="21">
-    <title>Abala ko̩kànlélógún.</title>
+    <title>Abala kọkànlélógún.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti kópa nínú ìs̩àkóso orílè̩‐èdè rè̩, yálà fúnra rè̩ tàbí nípasè̩ àwo̩n as̩ojú tí a kò fi ipá yàn.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti kópa nínú ìṣàkóso orílẹ̀‐èdè rẹ̀, yálà fúnra rẹ̀ tàbí nípasẹ̀ àwọn aṣojú tí a kò fi ipá yàn.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ tó dó̩gba láti s̩e is̩é̩ ìjo̩ba ní orílè̩‐èdè rè̩.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ tó dọ́gba láti ṣe iṣẹ́ ìjọba ní orílẹ̀‐èdè rẹ̀.</para>
       </listitem>
       <listitem>
-	<para>I fé̩ àwo̩n ènìyàn ìlú ni yóò jé̩ òkúta ìpìlè̩ fún à s̩e̩ ìjo̩ba; a ó máa fi ìfé̩ yìí hàn nípasè̩ ìbò tòótó̩ tí a ó máa dì láti ìgbà dé ìgbà, nínú èyí tí e̩nì kò̩ò̩kan yóò ní è̩tó̩ sí ìbò kan s̩os̩o tí a dì ní ìkò̩kò̩ tàbí nípasè̩ irú o̩ nà ìdìbò mìíràn tí ó bá irú ìdìbò bé̩è̩ mu.</para>
+	<para>I fẹ́ àwọn ènìyàn ìlú ni yóò jẹ́ òkúta ìpìlẹ̀ fún à ṣẹ ìjọba; a ó máa fi ìfẹ́ yìí hàn nípasẹ̀ ìbò tòótọ́ tí a ó máa dì láti ìgbà dé ìgbà, nínú èyí tí ẹnì kọ̀ọ̀kan yóò ní ẹ̀tọ́ sí ìbò kan ṣoṣo tí a dì ní ìkọ̀kọ̀ tàbí nípasẹ̀ irú ọ nà ìdìbò mìíràn tí ó bá irú ìdìbò bẹ́ẹ̀ mu.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="22">
     <title>Abala kejìlélógún.</title>
-    <para>E̩nì kò̩ò̩kan gé̩gé̩ bí è̩yà nínú àwùjo̩ ló ní è̩tó̩ sí ìdáàbò bò láti o̩wó̩ ìjo̩ba àti láti jé̩ àn fà ní àwo̩n è̩tó̩ tí ó bá o̩rò̩‐ajé, ìwà láwùjo̩ àti às̩à àbínibí mu; àwo̩n è̩tó̩ tí ó jé̩ kò‐s̩eé‐má‐nìí fún iyì àti ìdàgbàsókè è̩dá ènìyàn, nípa akitiyan nínú orílè̩‐èdè àti ìfo̩wó̩s̩owó̩ pò̩ láàrin àwo̩n orílè̩‐èdè ní ìbámu pè̩lú ètò àti ohun àlùmó̩nì orílè̩‐èdè kò̩ò̩kan.</para>
+    <para>Ẹnì kọ̀ọ̀kan gẹ́gẹ́ bí ẹ̀yà nínú àwùjọ ló ní ẹ̀tọ́ sí ìdáàbò bò láti ọwọ́ ìjọba àti láti jẹ́ àn fà ní àwọn ẹ̀tọ́ tí ó bá ọrọ̀‐ajé, ìwà láwùjọ àti àṣà àbínibí mu; àwọn ẹ̀tọ́ tí ó jẹ́ kò‐ṣeé‐má‐nìí fún iyì àti ìdàgbàsókè ẹ̀dá ènìyàn, nípa akitiyan nínú orílẹ̀‐èdè àti ìfọwọ́ṣowọ́ pọ̀ láàrin àwọn orílẹ̀‐èdè ní ìbámu pẹ̀lú ètò àti ohun àlùmọ́nì orílẹ̀‐èdè kọ̀ọ̀kan.</para>
   </article>
   <article number="23">
-    <title>Abala ke̩tàlélógún.</title>
+    <title>Abala kẹtàlélógún.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti s̩is̩é̩, láti yan irú is̩é̩ tí ó wù ú, lábé̩ àdéhùn tí ó tó̩ tí ó sì tún ro̩rùn, kí ó sì ní ààbò kúrò ló̩wó̩ àìrís̩é̩ s̩e.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti ṣiṣẹ́, láti yan irú iṣẹ́ tí ó wù ú, lábẹ́ àdéhùn tí ó tọ́ tí ó sì tún rọrùn, kí ó sì ní ààbò kúrò lọ́wọ́ àìríṣẹ́ ṣe.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti gba iye owó tí ó dó̩gba fún irú is̩é̩ kan náà, láìsí ìyàsó̩tò̩ kankan.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti gba iye owó tí ó dọ́gba fún irú iṣẹ́ kan náà, láìsí ìyàsọ́tọ̀ kankan.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan tí ó bá ń s̩isé̩ ní è̩tó̩ láti gba owó os̩ù tí ó tó̩ tí yóò sì tó fún òun àti e̩bí rè̩ láti gbé ayé tí ó bu iyì kún ènìyàn; a sì lè fi kún owó yìí nípasè̩ orís̩ìí àwo̩n ètò ìrànló̩wó̩ mìíràn nígbà tí ó bá ye.</para>
+	<para>Ẹnì kọ̀ọ̀kan tí ó bá ń ṣisẹ́ ní ẹ̀tọ́ láti gba owó oṣù tí ó tọ́ tí yóò sì tó fún òun àti ẹbí rẹ̀ láti gbé ayé tí ó bu iyì kún ènìyàn; a sì lè fi kún owó yìí nípasẹ̀ oríṣìí àwọn ètò ìrànlọ́wọ́ mìíràn nígbà tí ó bá ye.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti dá e̩gbé̩ òs̩ìs̩é̩ sílè̩ àti láti dara pò̩ mó̩ irú e̩gbe̩; bé̩è̩ láti dáàbò bo àwo̩n ohun tí ó je̩ é̩ lógún.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti dá ẹgbẹ́ òṣìṣẹ́ sílẹ̀ àti láti dara pọ̀ mọ́ irú ẹgbẹ; bẹ́ẹ̀ láti dáàbò bo àwọn ohun tí ó jẹ ẹ́ lógún.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="24">
-    <title>Abala ke̩rìnlélógún.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí ìsinmi àti fàájì pè̩lú àkókò tí kò pò̩ jù lé̩nu is̩é̩ àti àsìkò ìsinmi lé̩nu is̩é̩ láti ìgbà dé ìgbà tí a ó sanwó fún.</para>
+    <title>Abala kẹrìnlélógún.</title>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí ìsinmi àti fàájì pẹ̀lú àkókò tí kò pọ̀ jù lẹ́nu iṣẹ́ àti àsìkò ìsinmi lẹ́nu iṣẹ́ láti ìgbà dé ìgbà tí a ó sanwó fún.</para>
   </article>
   <article number="25">
-    <title>Abala ke̩è̩é̩dó̩gbò̩n.</title>
+    <title>Abala kẹẹ̀ẹ́dọ́gbọ̀n.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti gbé ìgbé ayé tó bójú mu nínú èyí tí òun àti e̩bí rè̩ yóò wà ní ìlera àti àlàáfíà, tí wo̩n yóò sì ní oúnje̩, as̩o̩, ilégbèé, àti àn fàní fún ìwòsàn àti gbogbo ohun tó lè mú è̩dá gbé ìgbé ayé rere. Bákan náà, e̩nì kò̩ò̩kan ló tún ní ààbò nígbà àìnís̩é̩ló̩wó̩, nígbà àìsà n, nígbà tó bá di aláàbò̩‐ara, ní ipò opó, nígbà ogbó rè̩ tàbí ìgbà mìíràn tí ènìyàn kò ní ò̩nà láti rí oúnje̩ òò jó̩, tí eléyìí kì í sì í s̩e è̩bi olúwa rè̩.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti gbé ìgbé ayé tó bójú mu nínú èyí tí òun àti ẹbí rẹ̀ yóò wà ní ìlera àti àlàáfíà, tí wọn yóò sì ní oúnjẹ, aṣọ, ilégbèé, àti àn fàní fún ìwòsàn àti gbogbo ohun tó lè mú ẹ̀dá gbé ìgbé ayé rere. Bákan náà, ẹnì kọ̀ọ̀kan ló tún ní ààbò nígbà àìníṣẹ́lọ́wọ́, nígbà àìsà n, nígbà tó bá di aláàbọ̀‐ara, ní ipò opó, nígbà ogbó rẹ̀ tàbí ìgbà mìíràn tí ènìyàn kò ní ọ̀nà láti rí oúnjẹ òò jọ́, tí eléyìí kì í sì í ṣe ẹ̀bi olúwa rẹ̀.</para>
       </listitem>
       <listitem>
-	<para>A ní láti pèsè ìtó̩jú àti ìrànló̩wó̩ pàtàkì fún àwo̩n abiyamo̩ àti àwo̩n o̩mo̩dé. Gbogbo àwo̩n o̩mo̩dé yóò máa je̩ àwo̩n àn fàní ààbò kan náà nínú àwùjo̩ yálà àwo̩n òbí wo̩n fé̩ ara wo̩n ni tàbí wo̩n kò fé̩ ara wo̩n.</para>
+	<para>A ní láti pèsè ìtọ́jú àti ìrànlọ́wọ́ pàtàkì fún àwọn abiyamọ àti àwọn ọmọdé. Gbogbo àwọn ọmọdé yóò máa jẹ àwọn àn fàní ààbò kan náà nínú àwùjọ yálà àwọn òbí wọn fẹ́ ara wọn ni tàbí wọn kò fẹ́ ara wọn.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="26">
-    <title>Abala ke̩rìndínló̩gbò̩n.</title>
+    <title>Abala kẹrìndínlọ́gbọ̀n.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láti kó̩ è̩kó̩. Ó kéré tán, è̩kó̩ gbo̩dò̩ jé̩ ò̩fé̩ ní àwo̩n ilé‐è̩kó̩ alákò̩ó̩bè̩rè̩. E̩kó̩ ní ilé‐è̩kó̩ alákò̩ó̩bè̩rè̩ yìí sì gbo̩dò̩ jé̩ dandan. A gbo̩dò̩ pèsè è̩kó̩ is̩é̩‐o̩wó̩, àti ti ìmò̩‐è̩ro̩ fún àwo̩n ènìyàn lápapò̩. Àn fàní tó dó̩gba ní ilé‐è̩kó̩ gíga gbo̩dò̩ wà ní àró̩wó̩tó gbogbo e̩ni tó bá tó̩ sí.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láti kọ́ ẹ̀kọ́. Ó kéré tán, ẹ̀kọ́ gbọdọ̀ jẹ́ ọ̀fẹ́ ní àwọn ilé‐ẹ̀kọ́ alákọ̀ọ́bẹ̀rẹ̀. Ẹkọ́ ní ilé‐ẹ̀kọ́ alákọ̀ọ́bẹ̀rẹ̀ yìí sì gbọdọ̀ jẹ́ dandan. A gbọdọ̀ pèsè ẹ̀kọ́ iṣẹ́‐ọwọ́, àti ti ìmọ̀‐ẹ̀rọ fún àwọn ènìyàn lápapọ̀. Àn fàní tó dọ́gba ní ilé‐ẹ̀kọ́ gíga gbọdọ̀ wà ní àrọ́wọ́tó gbogbo ẹni tó bá tọ́ sí.</para>
       </listitem>
       <listitem>
-	<para>Ohun tí yóò jé̩ ète è̩kó̩ ni láti mú ìlo̩síwájú tó péye bá è̩dá ènìyàn, kí ó sì túbò̩ rí i pé àwo̩n ènìyàn bò̩wò̩ fún è̩tó̩ o̩mo̩nìyàn àti àwo̩n òmìnira wo̩n, tó jé̩ kò‐s̩eé‐má‐nìí. E tò è̩kó̩ gbo̩dò̩ lè rí i pé è̩mí; ìgbó̩ra‐e̩ni‐yé, ìbágbépò̩ àlàáfíà, àti ìfé̩ ò̩ré̩‐sí‐ò̩ré̩ wà láàrin orílè̩‐èdè, láàrin è̩yà kan sí òmíràn àti láàrin e̩lé̩sìn kan sí òmíràn. E tò‐è̩kó̩ sì gbo̩dò̩ kún àwo̩n akitiyan Àjo̩‐ìsò̩kan orílè̩‐èdè àgbáyé ló̩wó̩ láti rí i pé àlàáfíà fìdí múlè̩.</para>
+	<para>Ohun tí yóò jẹ́ ète ẹ̀kọ́ ni láti mú ìlọsíwájú tó péye bá ẹ̀dá ènìyàn, kí ó sì túbọ̀ rí i pé àwọn ènìyàn bọ̀wọ̀ fún ẹ̀tọ́ ọmọnìyàn àti àwọn òmìnira wọn, tó jẹ́ kò‐ṣeé‐má‐nìí. E tò ẹ̀kọ́ gbọdọ̀ lè rí i pé ẹ̀mí; ìgbọ́ra‐ẹni‐yé, ìbágbépọ̀ àlàáfíà, àti ìfẹ́ ọ̀rẹ́‐sí‐ọ̀rẹ́ wà láàrin orílẹ̀‐èdè, láàrin ẹ̀yà kan sí òmíràn àti láàrin ẹlẹ́sìn kan sí òmíràn. E tò‐ẹ̀kọ́ sì gbọdọ̀ kún àwọn akitiyan Àjọ‐ìsọ̀kan orílẹ̀‐èdè àgbáyé lọ́wọ́ láti rí i pé àlàáfíà fìdí múlẹ̀.</para>
       </listitem>
       <listitem>
-	<para>Àwo̩n òbí ló ní è̩tó̩ tó ga jù lo̩ láti yan è̩kó̩ tí wó̩n bá fé̩ fún àwo̩n o̩mo̩ wo̩n.</para>
+	<para>Àwọn òbí ló ní ẹ̀tọ́ tó ga jù lọ láti yan ẹ̀kọ́ tí wọ́n bá fẹ́ fún àwọn ọmọ wọn.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="27">
-    <title>Abala ke̩tàdínló̩gbò̩n.</title>
+    <title>Abala kẹtàdínlọ́gbọ̀n.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ láìjé̩ pé a fi ipá mú un láti kópa nínú àpapò̩ ìgbé ayé àwùjo̩ rè̩, kí ó je̩ ìgbádùn gbogbo ohun àmús̩e̩ wà ibè̩, kí ó sì kópa nínú ìdàgbàsókè ìmò̩ sáyé̩n sì àti àwo̩n àn fàní tó ń ti ibè̩ jáde.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ láìjẹ́ pé a fi ipá mú un láti kópa nínú àpapọ̀ ìgbé ayé àwùjọ rẹ̀, kí ó jẹ ìgbádùn gbogbo ohun àmúṣẹ wà ibẹ̀, kí ó sì kópa nínú ìdàgbàsókè ìmọ̀ sáyẹ́n sì àti àwọn àn fàní tó ń ti ibẹ̀ jáde.</para>
       </listitem>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí ààbò àn fàní ìmo̩yì àti ohun ìní tí ó je̩ yo̩ láti inú is̩é̩ yòówù tí ó bá s̩e ìbáà s̩e ìmò̩ sáyé̩n sì, ìwé kíko̩ tàbí is̩é̩ o̩nà.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí ààbò àn fàní ìmọyì àti ohun ìní tí ó jẹ yọ láti inú iṣẹ́ yòówù tí ó bá ṣe ìbáà ṣe ìmọ̀ sáyẹ́n sì, ìwé kíkọ tàbí iṣẹ́ ọnà.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="28">
-    <title>Abala kejìdínló̩gbò̩n.</title>
-    <para>E̩nì kò̩ò̩kan ló ní è̩tó̩ sí ètò nínú àwùjo̩ rè̩ àti ní gbogbo àwùjo̩ àgbáyé níbi tí àwo̩n è̩tó̩ òmìnira tí a ti gbé kalè̩ nínú ìkéde yìí yóò ti jé̩ mímús̩e̩.</para>
+    <title>Abala kejìdínlọ́gbọ̀n.</title>
+    <para>Ẹnì kọ̀ọ̀kan ló ní ẹ̀tọ́ sí ètò nínú àwùjọ rẹ̀ àti ní gbogbo àwùjọ àgbáyé níbi tí àwọn ẹ̀tọ́ òmìnira tí a ti gbé kalẹ̀ nínú ìkéde yìí yóò ti jẹ́ mímúṣẹ.</para>
   </article>
   <article number="29">
-    <title>Abala ko̩kàndínló̩gbò̩n.</title>
+    <title>Abala kọkàndínlọ́gbọ̀n.</title>
     <orderedlist>
       <listitem>
-	<para>E̩nì kò̩ò̩kan ló ní àwo̩n ojús̩e kan sí àwùjo̩, nípasè̩ èyí tí ó fi lè s̩eé s̩e fún e̩ni náà láti ní ìdàgbàsókè kíkún gé̩gé̩ bí è̩dá ènìyàn.</para>
+	<para>Ẹnì kọ̀ọ̀kan ló ní àwọn ojúṣe kan sí àwùjọ, nípasẹ̀ èyí tí ó fi lè ṣeé ṣe fún ẹni náà láti ní ìdàgbàsókè kíkún gẹ́gẹ́ bí ẹ̀dá ènìyàn.</para>
       </listitem>
       <listitem>
-	<para>O fin yóò de e̩nì kò̩ò̩kan láti fi ò̩wò̩ àti ìmo̩yì tí ó tó̩ fún è̩tó̩ àti òmìnira àwo̩n e̩lòmíràn nígbà tí e̩ni náà bá ń lo àwo̩n è̩tó̩ àti òmìnira ara rè̩. E yí wà ní ìbámu pè̩lú ò̩nà tó ye̩, tó sì tó̩ láti fi báni lò nínú àwùjo̩ fún ire àti àlàáfíà àwùjo̩ náà nínú èyí tí ìjo̩ba yóò wà ló̩wó̩ gbogbo ènìyàn.</para>
+	<para>O fin yóò de ẹnì kọ̀ọ̀kan láti fi ọ̀wọ̀ àti ìmọyì tí ó tọ́ fún ẹ̀tọ́ àti òmìnira àwọn ẹlòmíràn nígbà tí ẹni náà bá ń lo àwọn ẹ̀tọ́ àti òmìnira ara rẹ̀. E yí wà ní ìbámu pẹ̀lú ọ̀nà tó yẹ, tó sì tọ́ láti fi báni lò nínú àwùjọ fún ire àti àlàáfíà àwùjọ náà nínú èyí tí ìjọba yóò wà lọ́wọ́ gbogbo ènìyàn.</para>
       </listitem>
       <listitem>
-	<para>A kò gbo̩dò̩ lo àwo̩n è̩tó̩ àti òmìnira wò̩nyí rárá, ní ò̩nà yòówù kó jé̩, tó bá lòdì sí àwo̩n ète àti ìgbékalè̩ Ajo̩‐àpapò̩ orílè̩‐èdè agbáyé.</para>
+	<para>A kò gbọdọ̀ lo àwọn ẹ̀tọ́ àti òmìnira wọ̀nyí rárá, ní ọ̀nà yòówù kó jẹ́, tó bá lòdì sí àwọn ète àti ìgbékalẹ̀ Ajọ‐àpapọ̀ orílẹ̀‐èdè agbáyé.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="30">
-    <title>Abala o̩gbò̩n.</title>
-    <para>A kò gbo̩dò̩ túmò̩ ohunkóhun nínú ìkéde yìí gé̩gé̩ bí ohun tí ó fún orílè̩‐èdè kan tàbí àkójo̩pò̩ àwo̩n ènìyàn kan tàbí e̩nìké̩ni ní è̩tó̩ láti s̩e ohunkóhun tí yóò mú ìparun bá èyíkéyìí nínú àwo̩n è̩tó̩ àti òmìnira tí a kéde yìí.</para>
+    <title>Abala ọgbọ̀n.</title>
+    <para>A kò gbọdọ̀ túmọ̀ ohunkóhun nínú ìkéde yìí gẹ́gẹ́ bí ohun tí ó fún orílẹ̀‐èdè kan tàbí àkójọpọ̀ àwọn ènìyàn kan tàbí ẹnìkẹ́ni ní ẹ̀tọ́ láti ṣe ohunkóhun tí yóò mú ìparun bá èyíkéyìí nínú àwọn ẹ̀tọ́ àti òmìnira tí a kéde yìí.</para>
   </article>
 </udhr>


### PR DESCRIPTION
Yoruba UDHR translation should use dot below U+0323 instead of vertical line below U+0329.

While the vertical line below does occur in printed text as an alternative to the dot below, the Unicode character used is typically the combining dot below or characters canonically composed with it.

The [CLDR Yoruba exemplar characters set](https://github.com/unicode-org/cldr/blob/main/common/main/yo.xml#L933) uses U+0323 and characters canonically composed with it.