### PR TITLE
Ticuna [tca]: replace U+035F by U+0331 under vowels

### DIFF
--- a/data/udhr/udhr_tca.xml
+++ b/data/udhr/udhr_tca.xml
@@ -9,12 +9,12 @@
     <para>Nüxü̃ tacua̱xgü rü ñuxguacü rü togü i ãẽ̱xgacügü rü chixri nüxna nadau i norü duü̃xü̃gü rü chixri namaã nachopetü. Rü wüxi i taxü̃ ĩ chixexü̃ nixĩ ĩ ngẽma ĩ guxü̃ ĩ duü̃xü̃güpe̱xewa. Rü ñu̱xma tanaxwa̱xe i guxü̃ ĩ duü̃xü̃gü i guxü̃ ĩ naãnewa rü meã namaxẽ. Rü tama name na texé nachu̱xuxü̃ ĩ ngẽma nüxü̃ yaxuxchaü̃xü̃ ĩ duü̃xü̃gü. Rü tama name na texé nachu̱xuxü̃ ĩ ngẽma nüxü̃́ yaxõgüaxü̃ ĩ duü̃xü̃gü. Rü tama name ĩ togüxü̃ na namuü̃ẽxü̃ ĩ duü̃xü̃gü.</para>
     <para>Rü tanaxümatügü i ñaã oregü erü tanaxwa̱xe i ãẽ̱xgacügü meã nüxna nadaugüxü̃ ĩ norü duü̃xü̃gü. Erü tama tanaxwa̱xe i yixcüra ṯacü rü chixexü̃ca̱x norü ãẽ̱xgacümaã nanuẽ ĩ duü̃xü̃gü rü namaã nügü nadai.</para>
     <para>Tama name ĩ wüxi i nachiü̃ãne rü to i nachiü̃ãnemaã nügü na naḏaixü.</para>
-    <para>Poperawa tanaxümatügü rü guxü̃ma ĩ nachiü̃ãnecü̃͟ãxgü i duü̃xü̃gü rü nawüxigu i Tupanape̱xewa rü tataxuma ya texé ta togüarü yexera ixĩxẽ. Rü yatügü rü ngexügü rü nawüxigu, rü wüxichigü rü name. Rü name nixĩ na naxãxchiruxü̃ ĩ guxü̃ ĩ duü̃xü̃gü rü name nixĩ na naxãwemüxü̃. Rü name nixĩ ĩ meã nügümaã na namaxẽxü̃ ĩ duü̃xü̃gü rü tama nügü na naḏaixü̃.</para>
+    <para>Poperawa tanaxümatügü rü guxü̃ma ĩ nachiü̃ãnecü̱̃ã̱xgü i duü̃xü̃gü rü nawüxigu i Tupanape̱xewa rü tataxuma ya texé ta togüarü yexera ixĩxẽ. Rü yatügü rü ngexügü rü nawüxigu, rü wüxichigü rü name. Rü name nixĩ na naxãxchiruxü̃ ĩ guxü̃ ĩ duü̃xü̃gü rü name nixĩ na naxãwemüxü̃. Rü name nixĩ ĩ meã nügümaã na namaxẽxü̃ ĩ duü̃xü̃gü rü tama nügü na naḏaixü̃.</para>
     <para>Rü guxãma ĩ yixemagü i ngutaque̱xegüxü̃ rü tapuracüechaü̃ na nüxü̃ nangü̃xẽẽgüxü̃ca̱x i guxü̃ma ĩ duü̃xü̃gü na aixcüma meã namaxẽxü̃ca̱x rü nataãẽgüxü̃ca̱x.</para>
     <para>Rü ñu̱xma tanaxwa̱xe i guxü̃ma ĩ duü̃xü̃gü nüxü̃ nacua̱xgü i ngẽma uneta. Rü ngẽmaca̱x name nixĩ na meã naxümatügüxü̃ na nüxü̃ nacua̱xgüxü̃ca̱x i guxü̃ma ĩ duü̃xü̃gü.</para>
     <para>GUXÃMA Ĩ YIXEMA Ĩ GUXÜ Ĩ NACHIÜ̃ÃNEWA NE ĨXẼ</para>
     <para>Rü nüxü̃ tixu rü ñatarügügü:</para>
-    <para>Rü nangẽxma ĩ maxü̃ ĩ mexü̃ ĩ guxü̃ ĩ duü̃xü̃güca̱x ixĩxü̃, rü taxucürüwa i texé tanachu̱xu i ngẽma. Rü tanaxwa̱xegü i guxü̃ ĩ nachiü̃ãnecü̃͟ãx i duü̃xü̃gü nüxü̃ nacua̱xgü i ngẽmachiga. Rü ngẽmaca̱x rü name nixĩ na guxü̃wama duü̃xü̃gü nanagúexẽẽgüxü̃ ĩ ngẽmachiga, na guxüma ĩ duü̃xü̃gü nüxü̃ nacua̱xgüxü̃ca̱x.</para>
+    <para>Rü nangẽxma ĩ maxü̃ ĩ mexü̃ ĩ guxü̃ ĩ duü̃xü̃güca̱x ixĩxü̃, rü taxucürüwa i texé tanachu̱xu i ngẽma. Rü tanaxwa̱xegü i guxü̃ ĩ nachiü̃ãnecü̱̃ã̱x i duü̃xü̃gü nüxü̃ nacua̱xgü i ngẽmachiga. Rü ngẽmaca̱x rü name nixĩ na guxü̃wama duü̃xü̃gü nanagúexẽẽgüxü̃ ĩ ngẽmachiga, na guxüma ĩ duü̃xü̃gü nüxü̃ nacua̱xgüxü̃ca̱x.</para>
   </preamble>
 
   <article number="1">
@@ -25,7 +25,7 @@
   <article number="2">
     <title>ARTICULO 2.</title>
     <para>Rü name nixĩ na wüxichigü i duü̃xü̃ meã namaxü̃xü̃ ngẽxgumarüü̃ i ñaã popera nüxü̃ ixuxürüü̃. Rü taxucürüwa i texé tanachu̱xu i ngẽma. Rü nüẽ́ta i ngexta nabuxgu i wüxi i duü̃xü̃, rü e̱xna ṯacũ rü duü̃xü̃ yixĩxgu. Rü nüẽ́ta ega yatü yixĩxgu rü e̱xna ngexü̃ yixĩxgu. Rü nüẽ́ta i ṯacü i nagawa yadexaxgu rü e̱xna ñuxãcü Tupanaãxü̃́ yaxõõgu. Rü nüẽ́ta ega ṯacü rü ãẽ̱xgacütanüxü̃ yixĩxgu rü e̱xna ṯacügu naxĩnügu. Rü nüẽ́ta ega namuãrü dĩẽruã̱xgu rü e̱xna tama. Erü guxü̃ ĩ duü̃xü̃güca̱x nixĩ ĩ ñaã maxü̃ ĩ mexü̃.</para>
-    <para>Rü nüẽ́ta ega ṯacü rü nachiü̃ãnecü̃͟ãx yixĩxgu i wüxi i duü̃xü̃, erü guxü ĩ nachiü̃͟ãx i duü̃xü̃güca̱x nixĩ ĩ ñaã maxü ĩ mexü̃.</para>
+    <para>Rü nüẽ́ta ega ṯacü rü nachiü̃ãnecü̱̃ã̱x yixĩxgu i wüxi i duü̃xü̃, erü guxü ĩ nachiü̱̃ã̱x i duü̃xü̃güca̱x nixĩ ĩ ñaã maxü ĩ mexü̃.</para>
   </article>
 
   <article number="3">
@@ -116,7 +116,7 @@
         <para>Marü name na wüxichigü i duü̃xü̃ãxü̃́ na nangẽxmaxü̃ ĩ norü bupane rü nachiü̃ãne.</para>
       </listitem>
       <listitem>
-        <para>Taxucürüwa wüxi i ãẽ̱xgacü nanapu i wüxi i duü̃xü̃arü bupane. Natürü ngẽxguma nanaxwa̱xegu i wüxi i duü̃xü̃ rü marü name na nüxna na yaxũxü̃ ĩ ngẽma nachiü̃ãne na to i nachiü̃ãnewa naxũxü̃ca̱x na ngẽ́maxü̃͟ãx yixĩxü̃ca̱x.</para>
+        <para>Taxucürüwa wüxi i ãẽ̱xgacü nanapu i wüxi i duü̃xü̃arü bupane. Natürü ngẽxguma nanaxwa̱xegu i wüxi i duü̃xü̃ rü marü name na nüxna na yaxũxü̃ ĩ ngẽma nachiü̃ãne na to i nachiü̃ãnewa naxũxü̃ca̱x na ngẽ́maxü̱̃ã̱x yixĩxü̃ca̱x.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -125,7 +125,7 @@
     <title>ARTICULO 16.</title>
     <orderedlist>
       <listitem>
-        <para>Ngẽxguma nayaxgu i yatü rü marü name na naxãmaxü̃. Rü ngẽxgumarüü̃ ĩ ngexü̃gü rü ngẽxguma nayaxgu rü marü name na naxãtexü̃. Rü nüẽ́ta ega ṯacü rü duü̃xü̃ yixĩxgu i nümagü rü e̱xna ṯacü rü nachiü̃ãnegü̃͟ãx yixĩxgu rü e̱xna ṯacü rü machiü̃ãnecü̃͟ã yixĩxgu rü e̱xna ñuxãcü Tupanaãxü̃́ yaxõãgu. Rü taxucürüwa texé nüxna tanachu̱xu i ngẽma na naxãmaxü̃ rü e̱xna naxãtéxü̃ rü e̱xna naxãxãcüxü̃. Rü ngẽma yatü rü ngẽma ngexü̃ rü nawüxigumare.</para>
+        <para>Ngẽxguma nayaxgu i yatü rü marü name na naxãmaxü̃. Rü ngẽxgumarüü̃ ĩ ngexü̃gü rü ngẽxguma nayaxgu rü marü name na naxãtexü̃. Rü nüẽ́ta ega ṯacü rü duü̃xü̃ yixĩxgu i nümagü rü e̱xna ṯacü rü nachiü̃ãnegü̱̃ã̱x yixĩxgu rü e̱xna ṯacü rü machiü̃ãnecü̱̃ã̱ yixĩxgu rü e̱xna ñuxãcü Tupanaãxü̃́ yaxõãgu. Rü taxucürüwa texé nüxna tanachu̱xu i ngẽma na naxãmaxü̃ rü e̱xna naxãtéxü̃ rü e̱xna naxãxãcüxü̃. Rü ngẽma yatü rü ngẽma ngexü̃ rü nawüxigumare.</para>
       </listitem>
       <listitem>
         <para>Rü ngẽxguma tama naxãtechaü̃gu i wüxi i ngexü̃ rü taxucürüwa texé tanamu na naxãtéxü̃ca̱x. Tü ngẽxgumarüü̃ ĩ yatüxü̃ rü ngẽxguma tama naxãmaxchaü̃gu rü taxucürüwa texé tanamu na naxãmaxü̃ca̱x.</para>
@@ -261,7 +261,7 @@
     <title>ARTICULO 29.</title>
     <orderedlist>
       <listitem>
-        <para>Rü name nixĩ na wüxichigü i duü̃xü̃ rü meã norü ĩãneca̱x napuracüxü̃ rü meã guxü̃ ĩ togü i norü ĩãnecü̃͟ãxgümaã namaxü̃xü̃.</para>
+        <para>Rü name nixĩ na wüxichigü i duü̃xü̃ rü meã norü ĩãneca̱x napuracüxü̃ rü meã guxü̃ ĩ togü i norü ĩãnecü̱̃ã̱xgümaã namaxü̃xü̃.</para>
       </listitem>
       <listitem>
         <para>Rü name nixĩ na meã namaxẽxü̃ ĩ guxü̃ma ĩ duü̃xü̃gü, natürü taxucürüwa texé chixri naga taxĩnü ĩ tümaãrü ãẽ̱xgacü. Rü tama name na wüxi i duü̃xü̃ rü to i duü̃xü̃maã chixexü̃ naxüxü̃.</para>

--- a/data/udhr/udhr_tca.xml
+++ b/data/udhr/udhr_tca.xml
@@ -210,7 +210,7 @@
 
   <article number="24">
     <title>ARTICULO 24.</title>
-    <para>Rü guxü̃ma ĩ duü̃xü̃gü rü name na nangü̃güxü̃ ĩ ñuxguacü na tama guxü̃guma napuracüexü̃ca̱x. Rü ngẽxguma wüxi ya taunecü wüxi i corixü̃tawa napuracügu i wüxi i duü̃xü̃ rü name nixĩ na ngẽma cori nüxna na nxãxü̃ ĩ ñuxre i ngunexü̃ na nan͟gü̃xü̃ca̱x. Rü name nixĩ na ngẽma ngunexü̃gü i nagu nan͟gü̃xü̃ ĩ ngẽma cori nüxü̃́ na naxütanüxü̃ naxc̱ax i ngẽma ngunexü̃gü i nagu naṉgü̃xü̃ ĩ ngẽma norü duü̃xü̃.</para>
+    <para>Rü guxü̃ma ĩ duü̃xü̃gü rü name na nangü̃güxü̃ ĩ ñuxguacü na tama guxü̃guma napuracüexü̃ca̱x. Rü ngẽxguma wüxi ya taunecü wüxi i corixü̃tawa napuracügu i wüxi i duü̃xü̃ rü name nixĩ na ngẽma cori nüxna na nxãxü̃ ĩ ñuxre i ngunexü̃ na nangü̃xü̃ca̱x. Rü name nixĩ na ngẽma ngunexü̃gü i nagu nangü̃xü̃ ĩ ngẽma cori nüxü̃́ na naxütanüxü̃ naxc̱ax i ngẽma ngunexü̃gü i nagu naṉgü̃xü̃ ĩ ngẽma norü duü̃xü̃.</para>
   </article>
 
   <article number="25">


### PR DESCRIPTION
- tca: replace U+035F by two U+0331 for vowels
  Ticana spelling uses U+0331 COMBINING MACRON BELOW under laringealized vowels.
  See:
    - Resolución Miniserial N° 730-2017-MINEDU, https://cdn.www.gob.pe/uploads/document/file/152595/_730-2017-MINEDU_-_04-01-2018_03_04_29_-RM_N__730-2017-MINEDU.pdf:
      > las vocales laringalizadas se escriben con una raya (_) debajo de la vocal.
  - Anderson and Anderson (2017), Diccionario ticuna — castellano, Lima: Intituto Lingüístico de Verano, https://www.sil.org/resources/archives/69858, p. vii
- tca: replace n͟g by ng
  Ticana spelling does not use n͟g but uses ng.
  See:
    - Resolución Miniserial N° 730-2017-MINEDU, https://cdn.www.gob.pe/uploads/document/file/152595/_730-2017-MINEDU_-_04-01-2018_03_04_29_-RM_N__730-2017-MINEDU.pdf
    - Anderson and Anderson (2017), Diccionario ticuna — castellano, Lima: Intituto Lingüístico de Verano, https://www.sil.org/resources/archives/69858, p. vii
