### PR TITLE
Central Mazahua [maz]: replace a{u0338}, u{0338} by ⱥ, ꞹ

### DIFF
--- a/data/udhr/udhr_maz.xml
+++ b/data/udhr/udhr_maz.xml
@@ -3,18 +3,18 @@
 <!--© The Office of the High Commisioner for Human Rights-->
 
 <udhr iso639-3='maz' xml:lang='maz' key='maz' n='Mazahua Central' dir='ltr' iso15924='Latn' xmlns="http://www.unicode.org/udhr">
-   <title>JÑA 'A YO PJOSU̸ TEXE YE TE̱'E̱ NUYO KA̸NRA̸ A XESE NE XOÑIJOMU</title>
+   <title>JÑA 'A YO PJOSꞸ TEXE YE TE̱'E̱ NUYO KA̸NRA̸ A XESE NE XOÑIJOMU</title>
    <preamble>
-      <title>PJU̸RU̸</title>
-      <para>Panru̸ji k'u̸ mara mimiji na joo texe yo nte̱'e̱ in dya ra chu̱nji, numa so'o k'u̸ ra mamu̸ji k'u̸ ri chjekjoji texezgoji.</para>
-      <para>Panru̸ji k'u̸ ma dya ri pjechiji texto yo jña'a nuyo nrra pjosu̸ ye nte̱'e̱, nudyama so'o k'u̸ ra potr'u̸ji yo in Kjuarma; ngek'ua nesta nura mbaraji k'u̸ ye nte̱'e̱, ma sa̸ja̸ kja ne xoñi jomu̸, na kjuana k'u̸ rambesi nura zi'i, ra so'o mamu̸ nu in jña'a ñeje ra eme nu K'inchi angeze.</para>
-      <para>Panru̸ji k'u̸ nuyo jña'a yo pjosu̸ ye nte̱'e̱ ximi nesta ra k'uatr'u̸ kja xiskuama, ngek'ua dya ra chu̱'u̱nji.</para>
-      <para>Panru̸ji k'u̸ nesta ra mimi na jo'o texto ye tr'ajñiñi.</para>
-      <para>Panru̸ji k'u̸ yo jñiñi ye jmuru̸ kja nu tr'angumu̸ a xoñijomu̸, o dyu̸su̸ji ye jña'a kja naja xiskuama, jango mamu̸ yo nrra pjosu̸ yo nte̱'e̱ ñeje mamu̸ k'u̸ yo b'ezo ñe ye nrrixo chjetroji, kjana xits'iji k'u̸ ra mbox k'u̸ji nura jok'u̸ji jango ri mimiji nu padya.</para>
-      <para>Panru̸ji k'u̸ nuyo nrrajñiñi yo o jmuru̸ji kja nu tr'angumu̸ kja xoñijomu̸, ngek'ua ra mbosu̸ji texto yo b'ezhi ñeje yo pjosu̸ ye nte̱'e̱.</para>
-      <para>Panru̸ji k'u̸ nu k'inchijiyo nu pjosu̸ yo b'ezo nrra na kjuana ngek'ua ra dyatrajiyo.</para>
-      <para>Nu jmunte̱ nu tr'angumu̸ mamu̸</para>
-      <para>Nu Jña'a yo Pjosu̸ Texe ye Te̱'e̱ nuyo Ka̸nra̸ a xese ne Xoñijomu̸ ngeje k'uatr'u̸ k'u̸ yo jñiñi ra mimiji na jo'o, ngek'ua ye nte̱'e̱ ñeje yo ngumu̸ nesta k'u̸ ra mbara yo, ga kjaba ra so'o ra jichi texto yo d'ieb'e panru̸ji, k'u̸ nuzgoji ri chjekjoji ra jandaji na jo'o yo in kjuarmaji yo na mimi yo nañ'io e jñiñi.</para>
+      <title>PJꞸRꞸ</title>
+      <para>Panrꞹji k'ꞹ mara mimiji na joo texe yo nte̱'e̱ in dya ra chu̱nji, numa so'o k'ꞹ ra mamꞹji k'ꞹ ri chjekjoji texezgoji.</para>
+      <para>Panrꞹji k'ꞹ ma dya ri pjechiji texto yo jña'a nuyo nrra pjosꞹ ye nte̱'e̱, nudyama so'o k'ꞹ ra potr'ꞹji yo in Kjuarma; ngek'ua nesta nura mbaraji k'ꞹ ye nte̱'e̱, ma sⱥjⱥ kja ne xoñi jomꞹ, na kjuana k'ꞹ rambesi nura zi'i, ra so'o mamꞹ nu in jña'a ñeje ra eme nu K'inchi angeze.</para>
+      <para>Panrꞹji k'ꞹ nuyo jña'a yo pjosꞹ ye nte̱'e̱ ximi nesta ra k'uatr'ꞹ kja xiskuama, ngek'ua dya ra chu̱'u̱nji.</para>
+      <para>Panrꞹji k'ꞹ nesta ra mimi na jo'o texto ye tr'ajñiñi.</para>
+      <para>Panrꞹji k'ꞹ yo jñiñi ye jmurꞹ kja nu tr'angumꞹ a xoñijomꞹ, o dyꞹsꞹji ye jña'a kja naja xiskuama, jango mamꞹ yo nrra pjosꞹ yo nte̱'e̱ ñeje mamꞹ k'ꞹ yo b'ezo ñe ye nrrixo chjetroji, kjana xits'iji k'ꞹ ra mbox k'ꞹji nura jok'ꞹji jango ri mimiji nu padya.</para>
+      <para>Panrꞹji k'ꞹ nuyo nrrajñiñi yo o jmurꞹji kja nu tr'angumꞹ kja xoñijomꞹ, ngek'ua ra mbosꞹji texto yo b'ezhi ñeje yo pjosꞹ ye nte̱'e̱.</para>
+      <para>Panrꞹji k'ꞹ nu k'inchijiyo nu pjosꞹ yo b'ezo nrra na kjuana ngek'ua ra dyatrajiyo.</para>
+      <para>Nu jmunte̱ nu tr'angumꞹ mamꞹ</para>
+      <para>Nu Jña'a yo Pjosꞹ Texe ye Te̱'e̱ nuyo Kⱥnrⱥ a xese ne Xoñijomꞹ ngeje k'uatr'ꞹ k'ꞹ yo jñiñi ra mimiji na jo'o, ngek'ua ye nte̱'e̱ ñeje yo ngumꞹ nesta k'ꞹ ra mbara yo, ga kjaba ra so'o ra jichi texto yo d'ieb'e panrꞹji, k'ꞹ nuzgoji ri chjekjoji ra jandaji na jo'o yo in kjuarmaji yo na mimi yo nañ'io e jñiñi.</para>
    </preamble>
    <article number="1">
       <title>PEZHE D'AJA (1)</title>
@@ -22,16 +22,16 @@
    </article>
    <article number="2">
       <title>PEZHE YEJE (2)</title>
-      <para>Texe yo nte̱'e̱ chjejutrjoji nza kja ga mamu̸ kja na Xiskuamana, zo yo dyaja b'ezo ri nañ'io yo in nze'e, zo ri nrixo, zo ri nañ'io nu in jña'a, o ye eme nu mizhokjimi, o yo dya yo pesi.</para>
+      <para>Texe yo nte̱'e̱ chjejutrjoji nza kja ga mamꞹ kja na Xiskuamana, zo yo dyaja b'ezo ri nañ'io yo in nze'e, zo ri nrixo, zo ri nañ'io nu in jña'a, o ye eme nu mizhokjimi, o yo dya yo pesi.</para>
       <para>Ximi, dya so'o nu ra juantrjoji ye nte̱'e̱ nuyo kja dadyo e ts'ibepji, o na mimi nu juemetrjo e jñiñi zo ri na nojo o ri ts'ik'etrjo.</para>
    </article>
    <article number="3">
       <title>PEZHE JÑI'I (3)</title>
-      <para>Texe yo b'ezo o nrrixo so'o ra ngara ñeje ra nok'u̸ ximi ra mbosu̸ji.</para>
+      <para>Texe yo b'ezo o nrrixo so'o ra ngara ñeje ra nok'ꞹ ximi ra mbosꞹji.</para>
    </article>
    <article number="4">
       <title>PEZHE NZIYO (4)</title>
-      <para>Dyakjo soo ra yab'u̸ji o ra zad'u̸ji, nzakja ga xits'iji nu xiskuamana.</para>
+      <para>Dyakjo soo ra yab'ꞹji o ra zad'ꞹji, nzakja ga xits'iji nu xiskuamana.</para>
    </article>
    <article number="5">
       <title>PEZHE TS'ITS'CHA (5)</title>
@@ -39,47 +39,47 @@
    </article>
    <article number="6">
       <title>PEZHE ÑANTO (6)</title>
-      <para>Texe yo nte̱'e̱, jango nzhodu̸, dya so'o ra ngontr'u̸ji kja pjoru̸.</para>
+      <para>Texe yo nte̱'e̱, jango nzhodꞹ, dya so'o ra ngontr'ꞹji kja pjorꞹ.</para>
    </article>
    <article number="7">
       <title>PENZHE YENCHO (7)</title>
-      <para>Chjetroji texe kja xiskuama yo pjoxku̸ji, texezgoji ra soo ra mboxk'u̸ji nzakja ga xits'iji na kjuamana.</para>
+      <para>Chjetroji texe kja xiskuama yo pjoxkꞹji, texezgoji ra soo ra mboxk'ꞹji nzakja ga xits'iji na kjuamana.</para>
    </article>
    <article number="8">
       <title>PEZHE JÑINCHO (8)</title>
-      <para>Texe b'ezo o nrrixo pesi yo mboste kja xiskuama, nujua jango ra ts'apu̸ji yo oru̸, nzakja nu kjuama yo ri pesigoji ye Me'bonrro.</para>
+      <para>Texe b'ezo o nrrixo pesi yo mboste kja xiskuama, nujua jango ra ts'apꞹji yo orꞹ, nzakja nu kjuama yo ri pesigoji ye Me'bonrro.</para>
    </article>
    <article number="9">
       <title>PEZHE NZHINCHO (9)</title>
-      <para>Dya kjo soo ra zu̸ru̸ji o ra ngontr'u̸ji kja pjoru̸.</para>
+      <para>Dya kjo soo ra zꞹrꞹji o ra ngontr'ꞹji kja pjorꞹ.</para>
    </article>
    <article number="10">
       <title>PEZHE D'YECH'A (10)</title>
-      <para>Texe b'ezo o nrrixo soo ra mbosu̸ji, k'u̸ ga chjetroji jango ga dya̸tr'a̸pu̸ji nu jojña'a, nzakja na mamu̸ nu xiskuama, nu ximi nesta ra xoru̸ ye b'ota.</para>
+      <para>Texe b'ezo o nrrixo soo ra mbosꞹji, k'ꞹ ga chjetroji jango ga dyⱥtr'ⱥpꞹji nu jojña'a, nzakja na mamꞹ nu xiskuama, nu ximi nesta ra xorꞹ ye b'ota.</para>
    </article>
    <article number="11">
       <title>PEZHE D'YECH'A D'AJA (11)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo so'o k'u̸ ra mbosu̸ji ma jyasu̸ji k'u̸ pjekjo o ts'a, ximi nesta ra jñanrra yo dyant_'e̱ jango ga pjendioji.</para>
+            <para>Texe b'ezo o nrrixo so'o k'ꞹ ra mbosꞹji ma jyasꞹji k'ꞹ pjekjo o ts'a, ximi nesta ra jñanrra yo dyant_'e̱ jango ga pjendioji.</para>
          </listitem>
          <listitem>
-            <para>Dyz kjo soo ra jya̸sa̸ji nuyo dya o ts'a, ga kjaba mamu̸ yo jñagoji ñeje nuna xiskuamana. Ximi dya kjo pje nrri ra ts'apu̸ji ma pjekjo o mbonu̸.</para>
+            <para>Dyz kjo soo ra jyⱥsⱥji nuyo dya o ts'a, ga kjaba mamꞹ yo jñagoji ñeje nuna xiskuamana. Ximi dya kjo pje nrri ra ts'apꞹji ma pjekjo o mbonꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>PEZHE D'YECH'A YEJE (12)</title>
-      <para>Dya kjo soo pjekjo ra ma xipjiji kja in nzumu̸, yo in nte̱'e̱ o jango na mimi nuyo nguechjene. Texe yo b'ezo o nrrizo soo ra mbosu̸jima.</para>
+      <para>Dya kjo soo pjekjo ra ma xipjiji kja in nzumꞹ, yo in nte̱'e̱ o jango na mimi nuyo nguechjene. Texe yo b'ezo o nrrizo soo ra mbosꞹjima.</para>
    </article>
    <article number="13">
       <title>PEZHE D'YECH'A A JÑI'I (13)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra nzhodu̸ o ra jya̸ba̸ in ngumu̸ jango nee angeze.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra nzhodꞹ o ra jyⱥbⱥ in ngumꞹ jango nee angeze.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra mbedye jango nee angeze, kja ra nzhogu̸ ma nee.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra mbedye jango nee angeze, kja ra nzhogꞹ ma nee.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -87,10 +87,10 @@
       <title>PEZHE D'YECH'A NZIYO (14)</title>
       <orderedlist>
          <listitem>
-            <para>Ma jod'u̸ji, texe b'ezo o nrrixo soo k'u̸ ra jyod'u̸ kjo ra mbosu̸, kja jñiñi jango ra nee.</para>
+            <para>Ma jod'ꞹji, texe b'ezo o nrrixo soo k'ꞹ ra jyod'ꞹ kjo ra mbosꞹ, kja jñiñi jango ra nee.</para>
          </listitem>
          <listitem>
-            <para>Nudya nu mboxte, dya kjo soo ra nguatu̸, ma d'a nte̱'e̱ pjekjo o ts'a, ngeje nu mamu̸ na ngumu̸ xoñi jomu̸.</para>
+            <para>Nudya nu mboxte, dya kjo soo ra nguatꞹ, ma d'a nte̱'e̱ pjekjo o ts'a, ngeje nu mamꞹ na ngumꞹ xoñi jomꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -98,10 +98,10 @@
       <title>PEZHE D'YECH'A TS'ITS'CHA (15)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo nesta d'a mejomu̸.</para>
+            <para>Texe b'ezo o nrrixo nesta d'a mejomꞹ.</para>
          </listitem>
          <listitem>
-            <para>Dya kjo soo k'u̸ ra ngupu̸ji nu mejomu̸ nu o juanu̸, o ra nee ra mbot'u̸pu̸.</para>
+            <para>Dya kjo soo k'ꞹ ra ngupꞹji nu mejomꞹ nu o juanꞹ, o ra nee ra mbot'ꞹpꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -109,13 +109,13 @@
       <title>PEZHE D'YECH'A ÑANTO (16)</title>
       <orderedlist>
          <listitem>
-            <para>Ya b'ezo ñeje ye nrrixo, ma a ma te'eji, soo k'u ra chju̱ntu̸ji in dya kjo so ra mamu̸ k'u̸ iyo, ga kjaba ra mbesiji yo neeji, zo ra nguaru̸ nu chjuntu̸.</para>
+            <para>Ya b'ezo ñeje ye nrrixo, ma a ma te'eji, soo k'u ra chju̱ntꞹji in dya kjo so ra mamꞹ k'ꞹ iyo, ga kjaba ra mbesiji yo neeji, zo ra nguarꞹ nu chjuntꞹ.</para>
          </listitem>
          <listitem>
-            <para>Ngetrjo ma ra nee yo tr'ii nuyo ra chjunt'u̸ soo k'u̸ ra ts'ajima.</para>
+            <para>Ngetrjo ma ra nee yo tr'ii nuyo ra chjunt'ꞹ soo k'ꞹ ra ts'ajima.</para>
          </listitem>
          <listitem>
-            <para>Nu chjuntu̸ ngeje nu nrra pjosu̸ nuyo jñiñi ngek'ua nesta k'u̸ xira mbosu̸jidyayo.</para>
+            <para>Nu chjuntꞹ ngeje nu nrra pjosꞹ nuyo jñiñi ngek'ua nesta k'ꞹ xira mbosꞹjidyayo.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -123,29 +123,29 @@
       <title>PEZHE D'YECH'A YENCHO (17)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra mbes'i na ts'ik'e jomu̸ o na punkju̸.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra mbes'i na ts'ik'e jomꞹ o na punkjꞹ.</para>
          </listitem>
          <listitem>
-            <para>Dya kjo soo ra nrrenbiji in jomu̸.</para>
+            <para>Dya kjo soo ra nrrenbiji in jomꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="18">
       <title>PEZHE D'YECH'A JÑINCHO (18)</title>
-      <para>Texe b'ezo o nrrixo soo k'u̸ ra ngichi yo ra nee, k'u̸ ra ma kja nits'imi nu ra juajnu̸; ximi soo k'u̸ ra pot'u̸ nu in nits'imi o mizhokjimi, zo ri d'ats'e o ri kjuleji, pa ra jichiji, ra ts'aji ñeje ra jandaji.</para>
+      <para>Texe b'ezo o nrrixo soo k'ꞹ ra ngichi yo ra nee, k'ꞹ ra ma kja nits'imi nu ra juajnꞹ; ximi soo k'ꞹ ra pot'ꞹ nu in nits'imi o mizhokjimi, zo ri d'ats'e o ri kjuleji, pa ra jichiji, ra ts'aji ñeje ra jandaji.</para>
    </article>
    <article number="19">
       <title>PEZHE D'YECH'A NZHINCHO (19)</title>
-      <para>Texe b'ezo o nrrixo soo k'u̸ mamu̸ yo k'inchi, nudyanu ximi pjosu̸ ngek'ua dya kjo pje ra xipji ma ra mamu̸ nuyo ngichi angeze nujua jango ra nee.</para>
+      <para>Texe b'ezo o nrrixo soo k'ꞹ mamꞹ yo k'inchi, nudyanu ximi pjosꞹ ngek'ua dya kjo pje ra xipji ma ra mamꞹ nuyo ngichi angeze nujua jango ra nee.</para>
    </article>
    <article number="20">
       <title>PEZHE DYOTE (20)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra jumru̸ ko yo dyaja e nte̱'e̱.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra jumrꞹ ko yo dyaja e nte̱'e̱.</para>
          </listitem>
          <listitem>
-            <para>Dya kjo soo k'u̸ ra nrrutr'u̸ kja yo jmuru̸.</para>
+            <para>Dya kjo soo k'ꞹ ra nrrutr'ꞹ kja yo jmurꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -153,49 +153,49 @@
       <title>PEZHE DYOTE D'AJA (21)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrixo soo k'u̸ ra juajnu̸ nuyo in xota kja in jñiñi, ra ts'ase o ra o kjokjo ra nrra̸ga̸.</para>
+            <para>Texe b'ezo o nrixo soo k'ꞹ ra juajnꞹ nuyo in xota kja in jñiñi, ra ts'ase o ra o kjokjo ra nrrⱥgⱥ.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ximi ra juanu̸ji angeze ngek'ua ra ts'a e sota kja in jñiñi.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ximi ra juanꞹji angeze ngek'ua ra ts'a e sota kja in jñiñi.</para>
          </listitem>
          <listitem>
-            <para>Nunu ra mamu̸ nu jñiñi ngejedyanu na kjuanu̸, ngek'ua ga kjaba ma ra juanu̸ji yo jmu, soo nu ra tsaji jango ga neeji angezeji.</para>
+            <para>Nunu ra mamꞹ nu jñiñi ngejedyanu na kjuanꞹ, ngek'ua ga kjaba ma ra juanꞹji yo jmu, soo nu ra tsaji jango ga neeji angezeji.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="22">
       <title>PEZHE DUOTE YEJE (22)</title>
-      <para>Texe b'ezo o nrrixo nujua na mimi kja d'a jñiñi soo k'u̸ ra mimi na jo'o, ga kjaba nu jñiñi jango o te'e, ximi nesta nu ra mbosu̸ angeze ngek'ua dya kjo ra chu̱nb'i ximi nesta ra unu b'epji, in ra jya̸ba̸ e ngumu̸ jango ra ma eñe.</para>
+      <para>Texe b'ezo o nrrixo nujua na mimi kja d'a jñiñi soo k'ꞹ ra mimi na jo'o, ga kjaba nu jñiñi jango o te'e, ximi nesta nu ra mbosꞹ angeze ngek'ua dya kjo ra chu̱nb'i ximi nesta ra unu b'epji, in ra jyⱥbⱥ e ngumꞹ jango ra ma eñe.</para>
    </article>
    <article number="23">
       <title>PEZHE DYOTE JÑI (23)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra pepji, ximi soo nu ra juajnu̸ jango nee k'u̸ ra pepji ngek'ua ra nrro na jo'o.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra pepji, ximi soo nu ra juajnꞹ jango nee k'ꞹ ra pepji ngek'ua ra nrro na jo'o.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo, dya nesta ra juanu̸ji, ngek'ua ra ngontr'u̸ji yo merio.</para>
+            <para>Texe b'ezo o nrrixo, dya nesta ra juanꞹji, ngek'ua ra ngontr'ꞹji yo merio.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo yo pepji, nesta ra nrroji na jo'o, ga kjaba ra so'o ra unu̸ k'u̸ ra zi'i yo in te̱'e̱, ximi ra mbosu̸ nu i jñiñi ma ra b'ezhi.</para>
+            <para>Texe b'ezo o nrrixo yo pepji, nesta ra nrroji na jo'o, ga kjaba ra so'o ra unꞹ k'ꞹ ra zi'i yo in te̱'e̱, ximi ra mbosꞹ nu i jñiñi ma ra b'ezhi.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra jmuru̸ji jango na pepji ngek'ua ra pjendio yo nrra pjosu̸ji.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra jmurꞹji jango na pepji ngek'ua ra pjendio yo nrra pjosꞹji.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
       <title>PEZHE DYOTE NZIYO (24)</title>
-      <para>Texe b'ezo o nrrixo soo k'u̸ ra soya, in ra ts'a nu ra nee, ximi ra pezheji yo zu̸nu̸ ma pepji kjana ra ngontr'u̸ji ma ra soya.</para>
+      <para>Texe b'ezo o nrrixo soo k'ꞹ ra soya, in ra ts'a nu ra nee, ximi ra pezheji yo zꞹnꞹ ma pepji kjana ra ngontr'ꞹji ma ra soya.</para>
    </article>
    <article number="25">
       <title>PEZHE DYOTE TS'ITS'CHA (25)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra mimi na jo'o, nu nrra ra mbosu̸ yo in te̱'e̱, nu nesta ra dya̸tr'a̸, nu ra ñoñu̸ji, nu ra jye'e b'ito, nu in ngumu̸ ñeje texto yo nrra b'ezhi; ximi soo k'u̸ ra mbosu̸ji ma dya ri pepji, ma ri sodye, ma pjekjo ri so'o, ma ri d'ase, ma a ri pale o ma otrjo k'u̸ ri ju̱'u̱ pa ra mimi.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra mimi na jo'o, nu nrra ra mbosꞹ yo in te̱'e̱, nu nesta ra dyⱥtr'ⱥ, nu ra ñoñꞹji, nu ra jye'e b'ito, nu in ngumꞹ ñeje texto yo nrra b'ezhi; ximi soo k'ꞹ ra mbosꞹji ma dya ri pepji, ma ri sodye, ma pjekjo ri so'o, ma ri d'ase, ma a ri pale o ma otrjo k'ꞹ ri ju̱'u̱ pa ra mimi.</para>
          </listitem>
          <listitem>
-            <para>Nuyo nana ñeje yo ts'itr'i ngeje yo nrra nesta k'u̸ ra pjosu̸ji. Texto yo kja ts'ilele nuyo sii in tara o iyo, ximi chjetrjoji kja yo dyaja.</para>
+            <para>Nuyo nana ñeje yo ts'itr'i ngeje yo nrra nesta k'ꞹ ra pjosꞹji. Texto yo kja ts'ilele nuyo sii in tara o iyo, ximi chjetrjoji kja yo dyaja.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -203,13 +203,13 @@
       <title>PEZHE DYOTE ÑANTO (26)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra xoru̸. Nu xoru̸ dya ra ngontr'ujinu ma ngeje k'u̸ kja pju̸ru̸jitrjo. Nu xoru̸ ne pju̸ru̸ ngeje nu na kjuana. Kjana yo dyaja ye a nojoji ri ts'a texeyoji; ma ra neji ra nguaru̸ji nu xonpute o dyate ra chjetrjoji kja textoji ma a nrroji.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra xorꞹ. Nu xorꞹ dya ra ngontr'ujinu ma ngeje k'ꞹ kja pjꞹrꞹjitrjo. Nu xorꞹ ne pjꞹrꞹ ngeje nu na kjuana. Kjana yo dyaja ye a nojoji ri ts'a texeyoji; ma ra neji ra nguarꞹji nu xonpute o dyate ra chjetrjoji kja textoji ma a nrroji.</para>
          </listitem>
          <listitem>
-            <para>Nu xoru̸ ngeje nu kja n'u̸ texe yo nte̱'e̱ ra jonteji ximi kja k'u ra mimi na jo'o nza kja kjuarmaji; ra ts'a nu k'inchi ñeje k'u̸ dya ra chu'u yo jñiñi ñeje ra mimi na jo'o yo te̱'e̱ ye jñatrjoji ximi ra pjoru̸ yo kja nu ngumu̸ yo pjosu̸ texe ye jñiñi yo ka̸nkra̸ a xese nu xoñijomu̸.</para>
+            <para>Nu xorꞹ ngeje nu kja n'ꞹ texe yo nte̱'e̱ ra jonteji ximi kja k'u ra mimi na jo'o nza kja kjuarmaji; ra ts'a nu k'inchi ñeje k'ꞹ dya ra chu'u yo jñiñi ñeje ra mimi na jo'o yo te̱'e̱ ye jñatrjoji ximi ra pjorꞹ yo kja nu ngumꞹ yo pjosꞹ texe ye jñiñi yo kⱥnkrⱥ a xese nu xoñijomꞹ.</para>
          </listitem>
          <listitem>
-            <para>Nuyo tara soo k'u̸ ra juajnu̸ pjembe yo xoru̸ yo ra jichiji yo in chi'i.</para>
+            <para>Nuyo tara soo k'ꞹ ra juajnꞹ pjembe yo xorꞹ yo ra jichiji yo in chi'i.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -217,33 +217,33 @@
       <title>PEZHE DYOTE YENCHO (27)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra juajnu̸ yo nrra mamu̸ k'u̸ ra mbos'u̸ k'u̸ ra mbara nuyo b'u̸b'u̸ji kja jñiñi, ga kjaba na kjuana k'u̸ ran teji.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra juajnꞹ yo nrra mamꞹ k'ꞹ ra mbos'ꞹ k'ꞹ ra mbara nuyo b'ꞹb'ꞹji kja jñiñi, ga kjaba na kjuana k'ꞹ ran teji.</para>
          </listitem>
          <listitem>
-            <para>Texe b'ezo o nrrixo soo k'u̸ ra nrro merio o ra mbaraji ma dyopju̸ e b'epji, nu dyopju̸ angeze.</para>
+            <para>Texe b'ezo o nrrixo soo k'ꞹ ra nrro merio o ra mbaraji ma dyopjꞹ e b'epji, nu dyopjꞹ angeze.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
       <title>PEZHE DYOTE JÑINCHO (28)</title>
-      <para>Texe b'ezo o nrrixo soo k'u̸ ra mamu̸ jango nee k'u̸ ra mimi kja in jñiñi o kja xoñijomu̸ nzakja ga mamu̸ kja na xiskuamana.</para>
+      <para>Texe b'ezo o nrrixo soo k'ꞹ ra mamꞹ jango nee k'ꞹ ra mimi kja in jñiñi o kja xoñijomꞹ nzakja ga mamꞹ kja na xiskuamana.</para>
    </article>
    <article number="29">
       <title>PEZHE DYOTE NZHINCHO (29)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo panru̸ k'u̸ nu in jñiñi ngeje nu nrra nesta ngek'ua ra mbesi yo nesta.</para>
+            <para>Texe b'ezo o nrrixo panrꞹ k'ꞹ nu in jñiñi ngeje nu nrra nesta ngek'ua ra mbesi yo nesta.</para>
          </listitem>
          <listitem>
-            <para>Nu nra nestaji nge k'u̸ ra kjaji yomasi ri neeji, texe e nte̱'e̱ nesta k'u̸ ra ts'a yo mamu̸ nu skuama ga kjanu ra mbaru̸ ja ga mimi in jango ga ne'e yo in dyojui ñeje ga jñanrru̸ na jo'o texto yo ja̸ra̸ a xes'e nu xoñi jomu̸.</para>
+            <para>Nu nra nestaji nge k'ꞹ ra kjaji yomasi ri neeji, texe e nte̱'e̱ nesta k'ꞹ ra ts'a yo mamꞹ nu skuama ga kjanu ra mbarꞹ ja ga mimi in jango ga ne'e yo in dyojui ñeje ga jñanrrꞹ na jo'o texto yo jⱥrⱥ a xes'e nu xoñi jomꞹ.</para>
          </listitem>
          <listitem>
-            <para>Nudyayo nrra pjosu̸ ye nte̱'e̱ dya soo, k'u̸ ra kjaji ma dya ri panru̸ji nu mamu̸ nu ngumu̸ nu pjosu̸ ye nte̱'e̱ yo ka̸nra̸ a xese nu xoñi jomu̸.</para>
+            <para>Nudyayo nrra pjosꞹ ye nte̱'e̱ dya soo, k'ꞹ ra kjaji ma dya ri panrꞹji nu mamꞹ nu ngumꞹ nu pjosꞹ ye nte̱'e̱ yo kⱥnrⱥ a xese nu xoñi jomꞹ.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
       <title>PEZHE JÑITE (30)</title>
-      <para>Nu xiskuamana so'o k'u̸ ra ts'a texto yo jñiñi yo ja̸ra̸ a xese nu xoñijomu̸ o ye nte̱'e̱, ngek'ua ra soo ra ts'aji ye ts'ibepji nu ra mbosu̸ texe ye te̱'e̱ nza kja ga mamu̸ na xiskuamana.</para>
+      <para>Nu xiskuamana so'o k'ꞹ ra ts'a texto yo jñiñi yo jⱥrⱥ a xese nu xoñijomꞹ o ye nte̱'e̱, ngek'ua ra soo ra ts'aji ye ts'ibepji nu ra mbosꞹ texe ye te̱'e̱ nza kja ga mamꞹ na xiskuamana.</para>
    </article>
 </udhr>

--- a/data/udhr/udhr_maz.xml
+++ b/data/udhr/udhr_maz.xml
@@ -61,7 +61,7 @@
       <title>PEZHE D'YECH'A D'AJA (11)</title>
       <orderedlist>
          <listitem>
-            <para>Texe b'ezo o nrrixo so'o k'ꞹ ra mbosꞹji ma jyasꞹji k'ꞹ pjekjo o ts'a, ximi nesta ra jñanrra yo dyant_'e̱ jango ga pjendioji.</para>
+            <para>Texe b'ezo o nrrixo so'o k'ꞹ ra mbosꞹji ma jyasꞹji k'ꞹ pjekjo o ts'a, ximi nesta ra jñanrra yo dyante̱'e̱ jango ga pjendioji.</para>
          </listitem>
          <listitem>
             <para>Dyz kjo soo ra jyⱥsⱥji nuyo dya o ts'a, ga kjaba mamꞹ yo jñagoji ñeje nuna xiskuamana. Ximi dya kjo pje nrri ra ts'apꞹji ma pjekjo o mbonꞹ.</para>


### PR DESCRIPTION
The Mazahua 1989 orthography uses letters with slash: ⱥ, ɇ, ø, ꞹ.
Unicode 5.0 added ⱥ, ɇ, Unicode 11.0 added ꞹ. Before that they were approximated with a̸, e̸, u̸.

This also replaces "nt_'e̱" by "nte̱'e̱" as in other occurences.