### PR TITLE
Chiltepec Chinantec [csa]: replace † by ɨ, replace U+030D, remove U+030E

### DIFF
--- a/data/udhr/udhr_csa.xml
+++ b/data/udhr/udhr_csa.xml
@@ -7,52 +7,52 @@
    <preamble>
       <title>NEBA LILIO</title>
       <para>Kö.</para>
-      <para>Ejmo' chu e kio tsa makaloo̱ ne sia majmo'juisɨ̱̍kio mukuu sia maours e kio kalaküs ï sia juyi' tinei' kio jusó kia' kure ï tasia li ko' sasiá' kio lejɨ̍ tsa rü jnia tsa tio̱ jila suo.</para>
+      <para>Ejmo' chu e kio tsa makaloo̱ ne sia majmo'juisɨ̱kio mukuu sia maours e kio kalaküs ï sia juyi' tinei' kio jusó kia' kure ï tasia li ko' sasiá' kio lejɨ tsa rü jnia tsa tio̱ jila suo.</para>
       <para>Tü.</para>
-      <para>Ejmo' e sasno sia kalaküs ne sia i kï̱ ekio jusó e kio sou e kani malɇ ï muguɨ̍ sia nioa e kio michii̱ kio mukuu ne e kio jua'ts ale kalɨ̱̍ jue'ga jmoo sañü' e ma kua kö mukuu e tiou jnia re lejɨ̍ tsa rüjnia, maka kɨ̍ y kö ne ekio tinï; Lii majï jau kiö ne jna lɨ̍ jäa soul li lijmo' jnia le nio jnia kio juisɇ kio.</para>
+      <para>Ejmo' e sasno sia kalaküs ne sia i kï̱ ekio jusó e kio sou e kani malɇ ï muguɨ sia nioa e kio michii̱ kio mukuu ne e kio jua'ts ale kalɨ̱ jue'ga jmoo sañü' e ma kua kö mukuu e tiou jnia re lejɨ tsa rüjnia, maka kɨ y kö ne ekio tinï; Lii majï jau kiö ne jna lɨ jäa soul li lijmo' jnia le nio jnia kio juisɇ kio.</para>
       <para>Ne̱.</para>
-      <para>Ejmo' kio jna juso̱ kio̱jnia i jmo i tsa lɨ̱̎ ta jue'; mojoo tsa ñü' li lijmos ii jusó ijmoo tsa juë' ini e kio tsa ni kï jo̱ kaäs muguɨ̍ ne ekio sia kues ijmonia lejɨ̍ ijnio jnia.</para>
+      <para>Ejmo' kio jna juso̱ kio̱jnia i jmo i tsa lɨ̱̈ ta jue'; mojoo tsa ñü' li lijmos ii jusó ijmoo tsa juë' ini e kio tsa ni kï jo̱ kaäs muguɨ ne ekio sia kues ijmonia lejɨ ijnio jnia.</para>
       <para>Kiü.</para>
-      <para>Ejmo' chu kio lejɨ̎ jnia jmo' tio̱ ilii ta ne ele' kiö ameï jö' kio le kö mukuu.</para>
+      <para>Ejmo' chu kio lejɨ̈ jnia jmo' tio̱ ilii ta ne ele' kiö ameï jö' kio le kö mukuu.</para>
       <para>Ñaa.</para>
-      <para>Ejmo'kio lejɨ̎ tsa juu ne ekio le kö mukuu e makajmos tso̱ ni lii jmo' ï jau juso̱ kio sañü' jï roo juyi' ne ikï nü sou ne kuré jmo' jusó le sañü' ne tsamɨ̎ y makalɇs' makalɨ̍ ijmo̱s sou re kio lejɨ̎ lene soo ti saɨ̍' kio tsa siä gï li jmos jue'ga kio lejɨ̎ tsaloo̱.</para>
+      <para>Ejmo'kio lejɨ̈ tsa juu ne ekio le kö mukuu e makajmos tso̱ ni lii jmo' ï jau juso̱ kio sañü' jï roo juyi' ne ikï nü sou ne kuré jmo' jusó le sañü' ne tsamɨ̈ y makalɇs' makalɨ ijmo̱s sou re kio lejɨ̈ lene soo ti saɨ' kio tsa siä gï li jmos jue'ga kio lejɨ̈ tsaloo̱.</para>
       <para>Jni.</para>
-      <para>Ejmo' re kio lejɨ̎ tsou tsa kua e'e jmos ilii re kio lejɨ̎ sou le kö mukuu, ne mako̱ mukuu ijmos kusoo̱ juso̱ kio tsa loo kati neiɨ̍ kio tsa ñu'; Ejmo' kö kio lejɨ̎ ilaa juso̱ ne saloo̱ i jue' ijmo̱' i kio ilii imakajua's.</para>
+      <para>Ejmo' re kio lejɨ̈ tsou tsa kua e'e jmos ilii re kio lejɨ̈ sou le kö mukuu, ne mako̱ mukuu ijmos kusoo̱ juso̱ kio tsa loo kati neiɨ kio tsa ñu'; Ejmo' kö kio lejɨ̈ ilaa juso̱ ne saloo̱ i jue' ijmo̱' i kio ilii imakajua's.</para>
       <para>Kió.</para>
-      <para>Jau kio lejɨ̎ ikajuats jï kalets kio mukuu kuo juso̱ kio tsou ijmos re kió lejɨ̎ juu ne mukuu jmo' kió, ne jmo rée kio tsou ne tsa kua nita tsosɨ̎ kio sane, jmos i li tɨ̎ e'e jau la̱ mako' yo̱ jusó i le' le no̱', ne iso̱ tös ta mojoo̱ lii re ni jmä̱ ne kio le kö mukuu, kalakü ne makachas kio mukuu ne jmo' isóo, kio leji juu leta̱ ue̱ mukuu kua tsa jmoo ai'.</para>
+      <para>Jau kio lejɨ̈ ikajuats jï kalets kio mukuu kuo juso̱ kio tsou ijmos re kió lejɨ̈ juu ne mukuu jmo' kió, ne jmo rée kio tsou ne tsa kua nita tsosɨ̈ kio sane, jmos i li tɨ̈ e'e jau la̱ mako' yo̱ jusó i le' le no̱', ne iso̱ tös ta mojoo̱ lii re ni jmä̱ ne kio le kö mukuu, kalakü ne makachas kio mukuu ne jmo' isóo, kio leji juu leta̱ ue̱ mukuu kua tsa jmoo ai'.</para>
    </preamble>
    <article number="1">
       <title>Jau Kö (1).</title>
-      <para>Lejɨ̎ ni sou tsa lisia̱ ija̱a sia ikou' ne kojo̱ jï ne juso̱ ne jmo' re ju i sɨ̍' jmo' nö sala̱ ne sasno.</para>
+      <para>Lejɨ̈ ni sou tsa lisia̱ ija̱a sia ikou' ne kojo̱ jï ne juso̱ ne jmo' re ju i sɨ' jmo' nö sala̱ ne sasno.</para>
    </article>
    <article number="2">
       <title>Jau Tü Rasɨ Kö (2).</title>
-      <para>Lejɨ̍ tsou sia juso̱o ne tsa makaloo jua'ts ne ila le' sia i sia lejɨ̎ tsa rü nia kö ini lejnia samɨ̎ ne sañü' jumeï jau kio kua' ne sale' jau kio tsa soo ini ne lejɨ̎ tsou eta jmo', le kö ni jmä̱, le kö jisia kau' ne j lisia tsa tiñii.</para>
-      <para>Tasia ligees ja̱ echitoo ni mixii ikajmos tsa soo ti iní ne ichitoö̱ ni mixii jï le' jï jmo' í le kö mukuu ne le kö ni jmä̱ ne le kö juu kio nia kio lejɨ̎ tsou, kö ni lekö juu kio tsa rüjnia ne tasia lii lekö mukuu; tasia lijmos lejɨ̎ inió nia guu kaäs muguɨ̍ tasia li kues inios jmos tasia makaloo.</para>
+      <para>Lejɨ tsou sia juso̱o ne tsa makaloo jua'ts ne ila le' sia i sia lejɨ̈ tsa rü nia kö ini lejnia samɨ̈ ne sañü' jumeï jau kio kua' ne sale' jau kio tsa soo ini ne lejɨ̈ tsou eta jmo', le kö ni jmä̱, le kö jisia kau' ne j lisia tsa tiñii.</para>
+      <para>Tasia ligees ja̱ echitoo ni mixii ikajmos tsa soo ti iní ne ichitoö̱ ni mixii jï le' jï jmo' í le kö mukuu ne le kö ni jmä̱ ne le kö juu kio nia kio lejɨ̈ tsou, kö ni lekö juu kio tsa rüjnia ne tasia lii lekö mukuu; tasia lijmos lejɨ̈ inió nia guu kaäs muguɨ tasia li kues inios jmos tasia makaloo.</para>
    </article>
    <article number="3">
       <title>Jau Ne (3).</title>
-      <para>Lejɨ̎ tsou lisiaa mukuu e tɨ̎ tsa makaloo ne lijmos i tsou.</para>
+      <para>Lejɨ̈ tsou lisiaa mukuu e tɨ̈ tsa makaloo ne lijmos i tsou.</para>
    </article>
    <article number="4">
       <title>Jau Kiü (4).</title>
-      <para>Jijaa̱ tsou sia lijmos ta lejä ja' ne tasia lijmos ta̱ samɨ̎ kusɨ̍leja̱ lajü; lejɨ̎ tsou kaa muguɨ̍ lajɨ̍ gï jmos ta̱ tasia relaɨ̍ lene le kö mukuu.</para>
+      <para>Jijaa̱ tsou sia lijmos ta lejä ja' ne tasia lijmos ta̱ samɨ̈ kusɨleja̱ lajü; lejɨ̈ tsou kaa muguɨ lajɨ gï jmos ta̱ tasia relaɨ lene le kö mukuu.</para>
    </article>
    <article number="5">
       <title>Jau Ñaa (5).</title>
-      <para>Ijaä̱ tasia lijmos i kaäs muguɨ̍ tasia lipaa̱s tsou; tasia lijmos laɨ̍ le tsapa ja' ne muguu ne.</para>
+      <para>Ijaä̱ tasia lijmos i kaäs muguɨ tasia lipaa̱s tsou; tasia lijmos laɨ le tsapa ja' ne muguu ne.</para>
    </article>
    <article number="6">
       <title>Jau Jñi (6).</title>
-      <para>Lejɨ̎ tsou litɨ̎ le kö mukuu mojoo̱ li kï ta̱ lejɨ̎ jau chitoo ni mixii.</para>
+      <para>Lejɨ̈ tsou litɨ̈ le kö mukuu mojoo̱ li kï ta̱ lejɨ̈ jau chitoo ni mixii.</para>
    </article>
    <article number="7">
       <title>Jau Kió (7).</title>
-      <para>Lejɨ̎ jnia li kurée tiní tsa juu ne sia; kurée litɨ̎ jmo' í le kö juu. Lejɨ̎ sia litɨ̎ kurée ijmos í sia re laɨ̍ lejɨ̎ tsa kaa muguɨ̍ ne tasia lijmoo jna na takajua'juu ne tasia re laɨ̍ tasia lijmo' lene itï' guɨ̍ jna tsa kaa muguɨ̍.</para>
+      <para>Lejɨ̈ jnia li kurée tiní tsa juu ne sia; kurée litɨ̈ jmo' í le kö juu. Lejɨ̈ sia litɨ̈ kurée ijmos í sia re laɨ lejɨ̈ tsa kaa muguɨ ne tasia lijmoo jna na takajua'juu ne tasia re laɨ tasia lijmo' lene itï' guɨ jna tsa kaa muguɨ.</para>
    </article>
    <article number="8">
       <title>Jau Jña (8).</title>
-      <para>Lejɨ̎ tsou esia litɨ̎ mojoo mixii kios, tiní tsa nita ni jmä tsa kï mojoo maours e kio sia relaɨ̍ mojoo lii ree mixii kios guɨ̍ tasia lijmo' tsou iti's e kio tsou e rée lati's makalakuɨ̎s e chitoo ni mixii litɨ̎.</para>
+      <para>Lejɨ̈ tsou esia litɨ̈ mojoo mixii kios, tiní tsa nita ni jmä tsa kï mojoo maours e kio sia relaɨ mojoo lii ree mixii kios guɨ tasia lijmo' tsou iti's e kio tsou e rée lati's makalakuɨ̈s e chitoo ni mixii litɨ̈.</para>
    </article>
    <article number="9">
       <title>Jau Ñü (9).</title>
@@ -60,31 +60,31 @@
    </article>
    <article number="10">
       <title>Jau Kia (10).</title>
-      <para>Lejɨ̎ tsou sia tɨ̎ kuree kio lejɨ̎, e ne ï sii lejɨ̎ tsou sia juso̱o gï siɨ̍ tsa lï ta tsamakaloo tasia jmos kió gaäs, mojoo li kï' e tɨ e jmos e kio nasoo̱ e kio soo̱ kios leji' chitoo ni mixii kio.</para>
+      <para>Lejɨ̈ tsou sia tɨ̈ kuree kio lejɨ̈, e ne ï sii lejɨ̈ tsou sia juso̱o gï siɨ tsa lï ta tsamakaloo tasia jmos kió gaäs, mojoo li kï' e tɨ e jmos e kio nasoo̱ e kio soo̱ kios leji' chitoo ni mixii kio.</para>
    </article>
    <article number="11">
       <title>Jau Kia Kö Rasɨ Kö (11).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou sia tɨ̎ li lijmos tasia siɨ̍ so̱ tasia malakiɨ so̱ lejua' ni mixii jï lijmos jï sii' lejɨ tsou i makajmos isó mojoo maji jo kios.</para>
+            <para>Lejɨ̈ tsou sia tɨ̈ li lijmos tasia siɨ so̱ tasia malakiɨ so̱ lejua' ni mixii jï lijmos jï sii' lejɨ tsou i makajmos isó mojoo maji jo kios.</para>
          </listitem>
          <listitem>
-            <para>Jijaa sia li ki'so̱o ikajmo's tasia iso̱o le kö ni jmä ne le kö mukuu. Tasia lijmo's inios tso̱o jue' ika jmos ale kalɨ̍.</para>
+            <para>Jijaa sia li ki'so̱o ikajmo's tasia iso̱o le kö ni jmä ne le kö mukuu. Tasia lijmo's inios tso̱o jue' ika jmos ale kalɨ.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>Jau Kia Tü (12).</title>
-      <para>Jijaa sia lijmo laɨ kio tsou jï kua, neit'kios tasia lile' jule kio tsou. Lejɨ̎ tsou tɨ̎ ijmos í lejɨ' chitoo ni mixii, tasia likaäs muguɨ.</para>
+      <para>Jijaa sia lijmo laɨ kio tsou jï kua, neit'kios tasia lile' jule kio tsou. Lejɨ̈ tsou tɨ̈ ijmos í lejɨ' chitoo ni mixii, tasia likaäs muguɨ.</para>
    </article>
    <article number="13">
       <title>Jau Kia Ne Rasɨ Kö (13).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ le kö ojuɨ̍ tsa makaloo ne li jmos neit'kios gï nios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ le kö ojuɨ tsa makaloo ne li jmos neit'kios gï nios.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ li kuiɨ̎' le kö mukuu lii kuiɨ juu kia' ne lii ligï' juu kios na lene jua' michii kios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ li kuiɨ̈' le kö mukuu lii kuiɨ juu kia' ne lii ligï' juu kios na lene jua' michii kios.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -92,10 +92,10 @@
       <title>Jau Kia Kiü Tasɨ Kö (14).</title>
       <orderedlist>
          <listitem>
-            <para>Tï ma nios saäs nü, lajɨ̍ tsou tɨ̎'lisoos tijo xia' jo limaour's rüs le kö mukuu.</para>
+            <para>Tï ma nios saäs nü, lajɨ tsou tɨ̈'lisoos tijo xia' jo limaour's rüs le kö mukuu.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ ila tɨ̎ tsou tasia lijmos ixia' ï jua' tsa kia mixii gï le' isiäs nü, elaɨ̍ i kajmo' ne tasia kajmo' gï kö sia lisaäs nü le kö mukuu.</para>
+            <para>Lejɨ̈ ila tɨ̈ tsou tasia lijmos ixia' ï jua' tsa kia mixii gï le' isiäs nü, elaɨ i kajmo' ne tasia kajmo' gï kö sia lisaäs nü le kö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -103,10 +103,10 @@
       <title>Jau Kia Ñaa Rasɨ Kö (15).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ kö juu ikua.</para>
+            <para>Lejɨ̈ tsou tɨ̈ kö juu ikua.</para>
          </listitem>
          <listitem>
-            <para>Jijaä̱ tsou tasia lijmos laɨ̍ kio rü' le kö juu kionia, jijaa tsou tasia lii di chï kuna tsou kio juu kionia ne le kö ni jmä.</para>
+            <para>Jijaä̱ tsou tasia lijmos laɨ kio rü' le kö juu kionia, jijaa tsou tasia lii di chï kuna tsou kio juu kionia ne le kö ni jmä.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -114,13 +114,13 @@
       <title>Jau Kia Jñi Rasɨ Kö (16).</title>
       <orderedlist>
          <listitem>
-            <para>Tsa ñu' ne tsamɨ̎ tima majɨ̍ngs kiajñaa ñii lejɨnia ema tɨ̎, lejɨ̍nia tsa liä ne tsa tio̱ le kö ni jmä kio tsa so̱ kua', tsa maligï kuo ne malijmo nei' kios le kö ni jmos í ka gii kuos, tí' maka gï' kuos, na tasia nios re rü'le gi goös li toös rü's.</para>
+            <para>Tsa ñu' ne tsamɨ̈ tima majɨngs kiajñaa ñii lejɨnia ema tɨ̈, lejɨnia tsa liä ne tsa tio̱ le kö ni jmä kio tsa so̱ kua', tsa maligï kuo ne malijmo nei' kios le kö ni jmos í ka gii kuos, tí' maka gï' kuos, na tasia nios re rü'le gi goös li toös rü's.</para>
          </listitem>
          <listitem>
             <para>Tima nios legi goös lii ligii kuos.</para>
          </listitem>
          <listitem>
-            <para>Ne tasia tsou tasia juu ne tɨ̎ tsou juu ejmos í kio tsou.</para>
+            <para>Ne tasia tsou tasia juu ne tɨ̈ tsou juu ejmos í kio tsou.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -128,7 +128,7 @@
       <title>Jau Kia Kio Rasɨ Kö (17).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou ti kio ngäs ne kio lejɨ̎.</para>
+            <para>Lejɨ̈ tsou ti kio ngäs ne kio lejɨ̈.</para>
          </listitem>
          <listitem>
             <para>Jijaa̱ sia likï' wue kio tsou.</para>
@@ -137,17 +137,17 @@
    </article>
    <article number="18">
       <title>Jau Kia Jñaa (18).</title>
-      <para>Lejɨ̎ tsou lii tɨ̎ ijua' sɨ̍'s tsa so̱ kua'. Ne tɨ̎ jna tsa kamɨ̎ gï kuaa tsa kue jupii nü ge' ti gï kuo' lii lijmo'chijo̱ juu o ni jmä o le kö mukuu mojoo e'e sami' ne tsa kä ne kio leji tsa rü' jnia.</para>
+      <para>Lejɨ̈ tsou lii tɨ̈ ijua' sɨ's tsa so̱ kua'. Ne tɨ̈ jna tsa kamɨ̈ gï kuaa tsa kue jupii nü ge' ti gï kuo' lii lijmo'chijo̱ juu o ni jmä o le kö mukuu mojoo e'e sami' ne tsa kä ne kio leji tsa rü' jnia.</para>
    </article>
    <article number="19">
       <title>Jau Kia Ñü (19).</title>
-      <para>Lejɨ̎ tsou tɨ̎ ili le' ne lii jmo' xii ila tɨ nü mojoo sia li jmo's nü tsou.</para>
+      <para>Lejɨ̈ tsou tɨ̈ ili le' ne lii jmo' xii ila tɨ nü mojoo sia li jmo's nü tsou.</para>
    </article>
    <article number="20">
       <title>Jau Kiú (20).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ lijmos ijua' sɨ̍'s, ne lii jmoo sou kalejɨ̍s mojoo tsatäs le kö juu mojoo jmos ta lejï.</para>
+            <para>Lejɨ̈ tsou tɨ̈ lijmos ijua' sɨ's, ne lii jmoo sou kalejɨs mojoo tsatäs le kö juu mojoo jmos ta lejï.</para>
          </listitem>
          <listitem>
             <para>Jijaa̱ tsou tasia lisoo na sia nios, soos na nios.</para>
@@ -158,49 +158,49 @@
       <title>Jau Kiú Rasɨ Kö (21).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ le' tiní tsa juu o tiní tsa nita le kö ni jmä, eli le' ku'tso tsa sï' ti ní tsa juu.</para>
+            <para>Lejɨ̈ tsou tɨ̈ le' tiní tsa juu o tiní tsa nita le kö ni jmä, eli le' ku'tso tsa sï' ti ní tsa juu.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ le' egɨ̍s köní lejɨ̎ ta lekö ni jmä.</para>
+            <para>Lejɨ̈ tsou tɨ̈ le' egɨs köní lejɨ̈ ta lekö ni jmä.</para>
          </listitem>
          <listitem>
-            <para>Eyoü sɨ̎ juu lejɨ tsou tsa sɨ̎i tiní nita tsako' mixii chima tsamakaloo lejɨ̎ tsou lekö mukuu.</para>
+            <para>Eyoü sɨ̈ juu lejɨ tsou tsa sɨ̈i tiní nita tsako' mixii chima tsamakaloo lejɨ̈ tsou lekö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="22">
       <title>Jau Kiú Tü (22).</title>
-      <para>Lejɨ̎ tsou tsa chitoo je̱ juu, ti jmos í le kö ni jmä le kö mukuu lejɨ̎ tsou tsa tö' köní tɨ̎ kau', makou's ne tsamakaloo ekio tsou lii jmo' re kio juu.</para>
+      <para>Lejɨ̈ tsou tsa chitoo je̱ juu, ti jmos í le kö ni jmä le kö mukuu lejɨ̈ tsou tsa tö' köní tɨ̈ kau', makou's ne tsamakaloo ekio tsou lii jmo' re kio juu.</para>
    </article>
    <article number="23">
       <title>Jau Kiú Ne (23).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ ta, tsamakaloo takios köre mojoo mayoü sɨ̎ lejɨ̎ tsou inɨ kö juu lejɨ̎ tsou sia makatɨ ta.</para>
+            <para>Lejɨ̈ tsou tɨ̈ ta, tsamakaloo takios köre mojoo mayoü sɨ̈ lejɨ̈ tsou inɨ kö juu lejɨ̈ tsou sia makatɨ ta.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ jmos ta ne emamäs kuré lejɨ̎ rüs ne jmos í ta̱ kios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ jmos ta ne emamäs kuré lejɨ̈ rüs ne jmos í ta̱ kios.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tsa dijmo ta tɨ̎ kau' kuré mojoo ku's tsa rüs, mojoo lisiä lejɨ̎ tsou tsa kua mukuu, mojoo e mayaäs e jua' nio̱ tsou.</para>
+            <para>Lejɨ̈ tsou tsa dijmo ta tɨ̈ kau' kuré mojoo ku's tsa rüs, mojoo lisiä lejɨ̈ tsou tsa kua mukuu, mojoo e mayaäs e jua' nio̱ tsou.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ jupií jna tiös kö jau lejɨ̎ tsou mojoo kö re jmos í kios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ jupií jna tiös kö jau lejɨ̈ tsou mojoo kö re jmos í kios.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
       <title>Jau Kiú Kiü (24).</title>
-      <para>Lejɨ̎ tsou tɨ̎ jupií mojoo jñaas kö wua mojoo ñaas ta kios na makaloös.</para>
+      <para>Lejɨ̈ tsou tɨ̈ jupií mojoo jñaas kö wua mojoo ñaas ta kios na makaloös.</para>
    </article>
    <article number="25">
       <title>Jau Kiú Ñaa Rasɨ Kö (25).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ kö ní mojoo kuas re lejɨ̎ tsa rüs, mojoo jmos í ni sɨ̍'s kios ne mojoo kuas re, ne mojoo ku're, mojoo tɨ̎ muküs, ne mojoo tɨ̎ nei' kios, mojoo tɨ̎ mɨ̎, ne mojoo li tɨ̎ lejɨ̎ ijmoü' nei' kios, mojoo tɨ̎ kö mixii ekuee jupií kia' mojoo kues mɨ̎ nakalasö, naka jü ñikuo' e mamäs kia'nü, na kuas na masadö sia lii jmo' ta e mamäs kia nü.</para>
+            <para>Lejɨ̈ tsou tɨ̈ kö ní mojoo kuas re lejɨ̈ tsa rüs, mojoo jmos í ni sɨ's kios ne mojoo kuas re, ne mojoo ku're, mojoo tɨ̈ muküs, ne mojoo tɨ̈ nei' kios, mojoo tɨ̈ mɨ̈, ne mojoo li tɨ̈ lejɨ̈ ijmoü' nei' kios, mojoo tɨ̈ kö mixii ekuee jupií kia' mojoo kues mɨ̈ nakalasö, naka jü ñikuo' e mamäs kia'nü, na kuas na masadö sia lii jmo' ta e mamäs kia nü.</para>
          </listitem>
          <listitem>
-            <para>Tïma ni' jo̱ns tɨ̎ ejmo' í ne̱ sɨ̎. Lejɨ̎ daü pí tsa lisiä ekio tsa di gï kuo tɨ̎ kure jmo' í.</para>
+            <para>Tïma ni' jo̱ns tɨ̈ ejmo' í ne̱ sɨ̈. Lejɨ̈ daü pí tsa lisiä ekio tsa di gï kuo tɨ̈ kure jmo' í.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -208,13 +208,13 @@
       <title>Jau Kiú Jñi Rasɨ Kö (26).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ e'es mixii. Tasia mamäs kio tɨ̎ kati kutɨ̍s xii kios, kati kuis xii jue' nasia kau' isia' xii ko's.</para>
+            <para>Lejɨ̈ tsou tɨ̈ e'es mixii. Tasia mamäs kio tɨ̈ kati kutɨs xii kios, kati kuis xii jue' nasia kau' isia' xii ko's.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou litɨ̎ xii tsa ñi̱ tɨ̎ ne tsamakaloo e ñis a le tɨ̍ le kö mukuu ne lejɨ̎ tsa le' jumeï, ne jmos lajɨ̍ ta sia le kö mukuu mojoo sia tï tsou.</para>
+            <para>Lejɨ̈ tsou litɨ̈ xii tsa ñi̱ tɨ̈ ne tsamakaloo e ñis a le tɨ le kö mukuu ne lejɨ̈ tsa le' jumeï, ne jmos lajɨ ta sia le kö mukuu mojoo sia tï tsou.</para>
          </listitem>
          <listitem>
-            <para>Jmeïs tɨ̎ inios e xii nios kio jös.</para>
+            <para>Jmeïs tɨ̈ inios e xii nios kio jös.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -222,33 +222,33 @@
       <title>Jau Kiú Kió Rasɨ Kö (27).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ ejmos tsamakalo̱ö ne jmos le inios juu kios mojoo liɨ̍s ta majau mojoo chä lejɨ̎ i tɨ̍s juu kios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ ejmos tsamakalo̱ö ne jmos le inios juu kios mojoo liɨs ta majau mojoo chä lejɨ̈ i tɨs juu kios.</para>
          </listitem>
          <listitem>
-            <para>Lejɨ̎ tsou tɨ̎ ne kues jupií tɨ̎ ne tsamakaloö, lejɨ̍ tsou lijmos xii kio jmeï kios.</para>
+            <para>Lejɨ̈ tsou tɨ̈ ne kues jupií tɨ̈ ne tsamakaloö, lejɨ tsou lijmos xii kio jmeï kios.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
       <title>Jau Kiú Jñaa (28).</title>
-      <para>Lejɨ̎ tsou tɨ̎ jmos kö jau le kö mukuu ne tɨ̎ tsamakaloo lejɨ̎ chitoo ni mixii mojoo jmoo jna isoo ta.</para>
+      <para>Lejɨ̈ tsou tɨ̈ jmos kö jau le kö mukuu ne tɨ̈ tsamakaloo lejɨ̈ chitoo ni mixii mojoo jmoo jna isoo ta.</para>
    </article>
    <article number="29">
       <title>Jau Kiú Ñü Rasɨ Kö (29).</title>
       <orderedlist>
          <listitem>
-            <para>Lejɨ̎ tsou esiaa ejmos ta tiní juu kios lii jmos ta tsamakaloo ne elijmos kio lejɨ̎ tsou.</para>
+            <para>Lejɨ̈ tsou esiaa ejmos ta tiní juu kios lii jmos ta tsamakaloo ne elijmos kio lejɨ̈ tsou.</para>
          </listitem>
          <listitem>
-            <para>E tɨ̎ tsou tsamakaloo̱ ne lejɨ̎ tsou esiɨ̎ ja̱ le chitoo ni mixii mojoo tɨ̎ jupií ne tɨ̎ tsamakaloo, lejɨ̎ tsou í mojoo re tiö tsou.</para>
+            <para>E tɨ̈ tsou tsamakaloo̱ ne lejɨ̈ tsou esiɨ̈ ja̱ le chitoo ni mixii mojoo tɨ̈ jupií ne tɨ̈ tsamakaloo, lejɨ̈ tsou í mojoo re tiö tsou.</para>
          </listitem>
          <listitem>
-            <para>Le tɨ̎ tsamakaloo tasia lijmos isia' le chitoo ni mixii le kö mukuu.</para>
+            <para>Le tɨ̈ tsamakaloo tasia lijmos isia' le chitoo ni mixii le kö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
       <title>Jau Kiú Kia (30).</title>
-      <para>Tasia chitoo ni mixii tasia li jmos jna isia' ijoo jmo'jna la chitoo ilaa mojoo kuee jupií ne tɨ̎ le kö ni jmä kö cha̱ tsou, elijmos ta mojoo lijmos kö tsó̱ lejɨ̎ tɨ̎ ne makaloo le ichitoo ni mixii la.</para>
+      <para>Tasia chitoo ni mixii tasia li jmos jna isia' ijoo jmo'jna la chitoo ilaa mojoo kuee jupií ne tɨ̈ le kö ni jmä kö cha̱ tsou, elijmos ta mojoo lijmos kö tsó̱ lejɨ̈ tɨ̈ ne makaloo le ichitoo ni mixii la.</para>
    </article>
 </udhr>

--- a/data/udhr/udhr_csa.xml
+++ b/data/udhr/udhr_csa.xml
@@ -7,52 +7,52 @@
    <preamble>
       <title>NEBA LILIO</title>
       <para>Kö.</para>
-      <para>Ejmo' chu e kio tsa makaloo̱ ne sia majmo'juis†̱̍kio mukuu sia maours e kio kalaküs ï sia juyi' tinei' kio jusó kia' kure ï tasia li ko' sasiá' kio lej†̍ tsa rü jnia tsa tio̱ jila suo.</para>
+      <para>Ejmo' chu e kio tsa makaloo̱ ne sia majmo'juisɨ̱̍kio mukuu sia maours e kio kalaküs ï sia juyi' tinei' kio jusó kia' kure ï tasia li ko' sasiá' kio lejɨ̍ tsa rü jnia tsa tio̱ jila suo.</para>
       <para>Tü.</para>
-      <para>Ejmo' e sasno sia kalaküs ne sia i kï̱ ekio jusó e kio sou e kani malɇ ï mugu†̍ sia nioa e kio michii̱ kio mukuu ne e kio jua'ts ale kal†̱̍ jue'ga jmoo sañü' e ma kua kö mukuu e tiou jnia re lej†̍ tsa rüjnia, maka k†̍ y kö ne ekio tinï; Lii majï jau kiö ne jna l†̍ jäa soul li lijmo' jnia le nio jnia kio juisɇ kio.</para>
+      <para>Ejmo' e sasno sia kalaküs ne sia i kï̱ ekio jusó e kio sou e kani malɇ ï muguɨ̍ sia nioa e kio michii̱ kio mukuu ne e kio jua'ts ale kalɨ̱̍ jue'ga jmoo sañü' e ma kua kö mukuu e tiou jnia re lejɨ̍ tsa rüjnia, maka kɨ̍ y kö ne ekio tinï; Lii majï jau kiö ne jna lɨ̍ jäa soul li lijmo' jnia le nio jnia kio juisɇ kio.</para>
       <para>Ne̱.</para>
-      <para>Ejmo' kio jna juso̱ kio̱jnia i jmo i tsa l†̱̎ ta jue'; mojoo tsa ñü' li lijmos ii jusó ijmoo tsa juë' ini e kio tsa ni kï jo̱ kaäs mugu†̍ ne ekio sia kues ijmonia lej†̍ ijnio jnia.</para>
+      <para>Ejmo' kio jna juso̱ kio̱jnia i jmo i tsa lɨ̱̎ ta jue'; mojoo tsa ñü' li lijmos ii jusó ijmoo tsa juë' ini e kio tsa ni kï jo̱ kaäs muguɨ̍ ne ekio sia kues ijmonia lejɨ̍ ijnio jnia.</para>
       <para>Kiü.</para>
-      <para>Ejmo' chu kio lej†̎ jnia jmo' tio̱ ilii ta ne ele' kiö ameï jö' kio le kö mukuu.</para>
+      <para>Ejmo' chu kio lejɨ̎ jnia jmo' tio̱ ilii ta ne ele' kiö ameï jö' kio le kö mukuu.</para>
       <para>Ñaa.</para>
-      <para>Ejmo'kio lej†̎ tsa juu ne ekio le kö mukuu e makajmos tso̱ ni lii jmo' ï jau juso̱ kio sañü' jï roo juyi' ne ikï nü sou ne kuré jmo' jusó le sañü' ne tsam†̎ y makalɇs' makal†̍ ijmo̱s sou re kio lej†̎ lene soo ti sa†̍' kio tsa siä gï li jmos jue'ga kio lej†̎ tsaloo̱.</para>
+      <para>Ejmo'kio lejɨ̎ tsa juu ne ekio le kö mukuu e makajmos tso̱ ni lii jmo' ï jau juso̱ kio sañü' jï roo juyi' ne ikï nü sou ne kuré jmo' jusó le sañü' ne tsamɨ̎ y makalɇs' makalɨ̍ ijmo̱s sou re kio lejɨ̎ lene soo ti saɨ̍' kio tsa siä gï li jmos jue'ga kio lejɨ̎ tsaloo̱.</para>
       <para>Jni.</para>
-      <para>Ejmo' re kio lej†̎ tsou tsa kua e'e jmos ilii re kio lej†̎ sou le kö mukuu, ne mako̱ mukuu ijmos kusoo̱ juso̱ kio tsa loo kati nei†̍ kio tsa ñu'; Ejmo' kö kio lej†̎ ilaa juso̱ ne saloo̱ i jue' ijmo̱' i kio ilii imakajua's.</para>
+      <para>Ejmo' re kio lejɨ̎ tsou tsa kua e'e jmos ilii re kio lejɨ̎ sou le kö mukuu, ne mako̱ mukuu ijmos kusoo̱ juso̱ kio tsa loo kati neiɨ̍ kio tsa ñu'; Ejmo' kö kio lejɨ̎ ilaa juso̱ ne saloo̱ i jue' ijmo̱' i kio ilii imakajua's.</para>
       <para>Kió.</para>
-      <para>Jau kio lej†̎ ikajuats jï kalets kio mukuu kuo juso̱ kio tsou ijmos re kió lej†̎ juu ne mukuu jmo' kió, ne jmo rée kio tsou ne tsa kua nita tsos†̎ kio sane, jmos i li t†̎ e'e jau la̱ mako' yo̱ jusó i le' le no̱', ne iso̱ tös ta mojoo̱ lii re ni jmä̱ ne kio le kö mukuu, kalakü ne makachas kio mukuu ne jmo' isóo, kio leji juu leta̱ ue̱ mukuu kua tsa jmoo ai'.</para>
+      <para>Jau kio lejɨ̎ ikajuats jï kalets kio mukuu kuo juso̱ kio tsou ijmos re kió lejɨ̎ juu ne mukuu jmo' kió, ne jmo rée kio tsou ne tsa kua nita tsosɨ̎ kio sane, jmos i li tɨ̎ e'e jau la̱ mako' yo̱ jusó i le' le no̱', ne iso̱ tös ta mojoo̱ lii re ni jmä̱ ne kio le kö mukuu, kalakü ne makachas kio mukuu ne jmo' isóo, kio leji juu leta̱ ue̱ mukuu kua tsa jmoo ai'.</para>
    </preamble>
    <article number="1">
       <title>Jau Kö (1).</title>
-      <para>Lej†̎ ni sou tsa lisia̱ ija̱a sia ikou' ne kojo̱ jï ne juso̱ ne jmo' re ju i s†̍' jmo' nö sala̱ ne sasno.</para>
+      <para>Lejɨ̎ ni sou tsa lisia̱ ija̱a sia ikou' ne kojo̱ jï ne juso̱ ne jmo' re ju i sɨ̍' jmo' nö sala̱ ne sasno.</para>
    </article>
    <article number="2">
-      <title>Jau Tü Ras† Kö (2).</title>
-      <para>Lej†̍ tsou sia juso̱o ne tsa makaloo jua'ts ne ila le' sia i sia lej†̎ tsa rü nia kö ini lejnia sam†̎ ne sañü' jumeï jau kio kua' ne sale' jau kio tsa soo ini ne lej†̎ tsou eta jmo', le kö ni jmä̱, le kö jisia kau' ne j lisia tsa tiñii.</para>
-      <para>Tasia ligees ja̱ echitoo ni mixii ikajmos tsa soo ti iní ne ichitoö̱ ni mixii jï le' jï jmo' í le kö mukuu ne le kö ni jmä̱ ne le kö juu kio nia kio lej†̎ tsou, kö ni lekö juu kio tsa rüjnia ne tasia lii lekö mukuu; tasia lijmos lej†̎ inió nia guu kaäs mugu†̍ tasia li kues inios jmos tasia makaloo.</para>
+      <title>Jau Tü Rasɨ Kö (2).</title>
+      <para>Lejɨ̍ tsou sia juso̱o ne tsa makaloo jua'ts ne ila le' sia i sia lejɨ̎ tsa rü nia kö ini lejnia samɨ̎ ne sañü' jumeï jau kio kua' ne sale' jau kio tsa soo ini ne lejɨ̎ tsou eta jmo', le kö ni jmä̱, le kö jisia kau' ne j lisia tsa tiñii.</para>
+      <para>Tasia ligees ja̱ echitoo ni mixii ikajmos tsa soo ti iní ne ichitoö̱ ni mixii jï le' jï jmo' í le kö mukuu ne le kö ni jmä̱ ne le kö juu kio nia kio lejɨ̎ tsou, kö ni lekö juu kio tsa rüjnia ne tasia lii lekö mukuu; tasia lijmos lejɨ̎ inió nia guu kaäs muguɨ̍ tasia li kues inios jmos tasia makaloo.</para>
    </article>
    <article number="3">
       <title>Jau Ne (3).</title>
-      <para>Lej†̎ tsou lisiaa mukuu e t†̎ tsa makaloo ne lijmos i tsou.</para>
+      <para>Lejɨ̎ tsou lisiaa mukuu e tɨ̎ tsa makaloo ne lijmos i tsou.</para>
    </article>
    <article number="4">
       <title>Jau Kiü (4).</title>
-      <para>Jijaa̱ tsou sia lijmos ta lejä ja' ne tasia lijmos ta̱ sam†̎ kus†̍leja̱ lajü; lej†̎ tsou kaa mugu†̍ laj†̍ gï jmos ta̱ tasia rela†̍ lene le kö mukuu.</para>
+      <para>Jijaa̱ tsou sia lijmos ta lejä ja' ne tasia lijmos ta̱ samɨ̎ kusɨ̍leja̱ lajü; lejɨ̎ tsou kaa muguɨ̍ lajɨ̍ gï jmos ta̱ tasia relaɨ̍ lene le kö mukuu.</para>
    </article>
    <article number="5">
       <title>Jau Ñaa (5).</title>
-      <para>Ijaä̱ tasia lijmos i kaäs mugu†̍ tasia lipaa̱s tsou; tasia lijmos la†̍ le tsapa ja' ne muguu ne.</para>
+      <para>Ijaä̱ tasia lijmos i kaäs muguɨ̍ tasia lipaa̱s tsou; tasia lijmos laɨ̍ le tsapa ja' ne muguu ne.</para>
    </article>
    <article number="6">
       <title>Jau Jñi (6).</title>
-      <para>Lej†̎ tsou lit†̎ le kö mukuu mojoo̱ li kï ta̱ lej†̎ jau chitoo ni mixii.</para>
+      <para>Lejɨ̎ tsou litɨ̎ le kö mukuu mojoo̱ li kï ta̱ lejɨ̎ jau chitoo ni mixii.</para>
    </article>
    <article number="7">
       <title>Jau Kió (7).</title>
-      <para>Lej†̎ jnia li kurée tiní tsa juu ne sia; kurée lit†̎ jmo' í le kö juu. Lej†̎ sia lit†̎ kurée ijmos í sia re la†̍ lej†̎ tsa kaa mugu†̍ ne tasia lijmoo jna na takajua'juu ne tasia re la†̍ tasia lijmo' lene itï' gu†̍ jna tsa kaa mugu†̍.</para>
+      <para>Lejɨ̎ jnia li kurée tiní tsa juu ne sia; kurée litɨ̎ jmo' í le kö juu. Lejɨ̎ sia litɨ̎ kurée ijmos í sia re laɨ̍ lejɨ̎ tsa kaa muguɨ̍ ne tasia lijmoo jna na takajua'juu ne tasia re laɨ̍ tasia lijmo' lene itï' guɨ̍ jna tsa kaa muguɨ̍.</para>
    </article>
    <article number="8">
       <title>Jau Jña (8).</title>
-      <para>Lej†̎ tsou esia lit†̎ mojoo mixii kios, tiní tsa nita ni jmä tsa kï mojoo maours e kio sia rela†̍ mojoo lii ree mixii kios gu†̍ tasia lijmo' tsou iti's e kio tsou e rée lati's makalaku†̎s e chitoo ni mixii lit†̎.</para>
+      <para>Lejɨ̎ tsou esia litɨ̎ mojoo mixii kios, tiní tsa nita ni jmä tsa kï mojoo maours e kio sia relaɨ̍ mojoo lii ree mixii kios guɨ̍ tasia lijmo' tsou iti's e kio tsou e rée lati's makalakuɨ̎s e chitoo ni mixii litɨ̎.</para>
    </article>
    <article number="9">
       <title>Jau Ñü (9).</title>
@@ -60,75 +60,75 @@
    </article>
    <article number="10">
       <title>Jau Kia (10).</title>
-      <para>Lej†̎ tsou sia t†̎ kuree kio lej†̎, e ne ï sii lej†̎ tsou sia juso̱o gï si†̍ tsa lï ta tsamakaloo tasia jmos kió gaäs, mojoo li kï' e t† e jmos e kio nasoo̱ e kio soo̱ kios leji' chitoo ni mixii kio.</para>
+      <para>Lejɨ̎ tsou sia tɨ̎ kuree kio lejɨ̎, e ne ï sii lejɨ̎ tsou sia juso̱o gï siɨ̍ tsa lï ta tsamakaloo tasia jmos kió gaäs, mojoo li kï' e tɨ e jmos e kio nasoo̱ e kio soo̱ kios leji' chitoo ni mixii kio.</para>
    </article>
    <article number="11">
-      <title>Jau Kia Kö Ras† Kö (11).</title>
+      <title>Jau Kia Kö Rasɨ Kö (11).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou sia t†̎ li lijmos tasia si†̍ so̱ tasia malaki† so̱ lejua' ni mixii jï lijmos jï sii' lej† tsou i makajmos isó mojoo maji jo kios.</para>
+            <para>Lejɨ̎ tsou sia tɨ̎ li lijmos tasia siɨ̍ so̱ tasia malakiɨ so̱ lejua' ni mixii jï lijmos jï sii' lejɨ tsou i makajmos isó mojoo maji jo kios.</para>
          </listitem>
          <listitem>
-            <para>Jijaa sia li ki'so̱o ikajmo's tasia iso̱o le kö ni jmä ne le kö mukuu. Tasia lijmo's inios tso̱o jue' ika jmos ale kal†̍.</para>
+            <para>Jijaa sia li ki'so̱o ikajmo's tasia iso̱o le kö ni jmä ne le kö mukuu. Tasia lijmo's inios tso̱o jue' ika jmos ale kalɨ̍.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>Jau Kia Tü (12).</title>
-      <para>Jijaa sia lijmo la† kio tsou jï kua, neit'kios tasia lile' jule kio tsou. Lej†̎ tsou t†̎ ijmos í lej†' chitoo ni mixii, tasia likaäs mugu†.</para>
+      <para>Jijaa sia lijmo laɨ kio tsou jï kua, neit'kios tasia lile' jule kio tsou. Lejɨ̎ tsou tɨ̎ ijmos í lejɨ' chitoo ni mixii, tasia likaäs muguɨ.</para>
    </article>
    <article number="13">
-      <title>Jau Kia Ne Ras† Kö (13).</title>
+      <title>Jau Kia Ne Rasɨ Kö (13).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ le kö oju†̍ tsa makaloo ne li jmos neit'kios gï nios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ le kö ojuɨ̍ tsa makaloo ne li jmos neit'kios gï nios.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou t†̎ li kui†̎' le kö mukuu lii kui† juu kia' ne lii ligï' juu kios na lene jua' michii kios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ li kuiɨ̎' le kö mukuu lii kuiɨ juu kia' ne lii ligï' juu kios na lene jua' michii kios.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="14">
-      <title>Jau Kia Kiü Tas† Kö (14).</title>
+      <title>Jau Kia Kiü Tasɨ Kö (14).</title>
       <orderedlist>
          <listitem>
-            <para>Tï ma nios saäs nü, laj†̍ tsou t†̎'lisoos tijo xia' jo limaour's rüs le kö mukuu.</para>
+            <para>Tï ma nios saäs nü, lajɨ̍ tsou tɨ̎'lisoos tijo xia' jo limaour's rüs le kö mukuu.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ ila t†̎ tsou tasia lijmos ixia' ï jua' tsa kia mixii gï le' isiäs nü, ela†̍ i kajmo' ne tasia kajmo' gï kö sia lisaäs nü le kö mukuu.</para>
+            <para>Lejɨ̎ ila tɨ̎ tsou tasia lijmos ixia' ï jua' tsa kia mixii gï le' isiäs nü, elaɨ̍ i kajmo' ne tasia kajmo' gï kö sia lisaäs nü le kö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="15">
-      <title>Jau Kia Ñaa Ras† Kö (15).</title>
+      <title>Jau Kia Ñaa Rasɨ Kö (15).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ kö juu ikua.</para>
+            <para>Lejɨ̎ tsou tɨ̎ kö juu ikua.</para>
          </listitem>
          <listitem>
-            <para>Jijaä̱ tsou tasia lijmos la†̍ kio rü' le kö juu kionia, jijaa tsou tasia lii di chï kuna tsou kio juu kionia ne le kö ni jmä.</para>
+            <para>Jijaä̱ tsou tasia lijmos laɨ̍ kio rü' le kö juu kionia, jijaa tsou tasia lii di chï kuna tsou kio juu kionia ne le kö ni jmä.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="16">
-      <title>Jau Kia Jñi Ras† Kö (16).</title>
+      <title>Jau Kia Jñi Rasɨ Kö (16).</title>
       <orderedlist>
          <listitem>
-            <para>Tsa ñu' ne tsam†̎ tima maj†̍ngs kiajñaa ñii lej†nia ema t†̎, lej†̍nia tsa liä ne tsa tio̱ le kö ni jmä kio tsa so̱ kua', tsa maligï kuo ne malijmo nei' kios le kö ni jmos í ka gii kuos, tí' maka gï' kuos, na tasia nios re rü'le gi goös li toös rü's.</para>
+            <para>Tsa ñu' ne tsamɨ̎ tima majɨ̍ngs kiajñaa ñii lejɨnia ema tɨ̎, lejɨ̍nia tsa liä ne tsa tio̱ le kö ni jmä kio tsa so̱ kua', tsa maligï kuo ne malijmo nei' kios le kö ni jmos í ka gii kuos, tí' maka gï' kuos, na tasia nios re rü'le gi goös li toös rü's.</para>
          </listitem>
          <listitem>
             <para>Tima nios legi goös lii ligii kuos.</para>
          </listitem>
          <listitem>
-            <para>Ne tasia tsou tasia juu ne t†̎ tsou juu ejmos í kio tsou.</para>
+            <para>Ne tasia tsou tasia juu ne tɨ̎ tsou juu ejmos í kio tsou.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="17">
-      <title>Jau Kia Kio Ras† Kö (17).</title>
+      <title>Jau Kia Kio Rasɨ Kö (17).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou ti kio ngäs ne kio lej†̎.</para>
+            <para>Lejɨ̎ tsou ti kio ngäs ne kio lejɨ̎.</para>
          </listitem>
          <listitem>
             <para>Jijaa̱ sia likï' wue kio tsou.</para>
@@ -137,17 +137,17 @@
    </article>
    <article number="18">
       <title>Jau Kia Jñaa (18).</title>
-      <para>Lej†̎ tsou lii t†̎ ijua' s†̍'s tsa so̱ kua'. Ne t†̎ jna tsa kam†̎ gï kuaa tsa kue jupii nü ge' ti gï kuo' lii lijmo'chijo̱ juu o ni jmä o le kö mukuu mojoo e'e sami' ne tsa kä ne kio leji tsa rü' jnia.</para>
+      <para>Lejɨ̎ tsou lii tɨ̎ ijua' sɨ̍'s tsa so̱ kua'. Ne tɨ̎ jna tsa kamɨ̎ gï kuaa tsa kue jupii nü ge' ti gï kuo' lii lijmo'chijo̱ juu o ni jmä o le kö mukuu mojoo e'e sami' ne tsa kä ne kio leji tsa rü' jnia.</para>
    </article>
    <article number="19">
       <title>Jau Kia Ñü (19).</title>
-      <para>Lej†̎ tsou t†̎ ili le' ne lii jmo' xii ila t† nü mojoo sia li jmo's nü tsou.</para>
+      <para>Lejɨ̎ tsou tɨ̎ ili le' ne lii jmo' xii ila tɨ nü mojoo sia li jmo's nü tsou.</para>
    </article>
    <article number="20">
       <title>Jau Kiú (20).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ lijmos ijua' s†̍'s, ne lii jmoo sou kalej†̍s mojoo tsatäs le kö juu mojoo jmos ta lejï.</para>
+            <para>Lejɨ̎ tsou tɨ̎ lijmos ijua' sɨ̍'s, ne lii jmoo sou kalejɨ̍s mojoo tsatäs le kö juu mojoo jmos ta lejï.</para>
          </listitem>
          <listitem>
             <para>Jijaa̱ tsou tasia lisoo na sia nios, soos na nios.</para>
@@ -155,100 +155,100 @@
       </orderedlist>
    </article>
    <article number="21">
-      <title>Jau Kiú Ras† Kö (21).</title>
+      <title>Jau Kiú Rasɨ Kö (21).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ le' tiní tsa juu o tiní tsa nita le kö ni jmä, eli le' ku'tso tsa sï' ti ní tsa juu.</para>
+            <para>Lejɨ̎ tsou tɨ̎ le' tiní tsa juu o tiní tsa nita le kö ni jmä, eli le' ku'tso tsa sï' ti ní tsa juu.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou t†̎ le' eg†̍s köní lej†̎ ta lekö ni jmä.</para>
+            <para>Lejɨ̎ tsou tɨ̎ le' egɨ̍s köní lejɨ̎ ta lekö ni jmä.</para>
          </listitem>
          <listitem>
-            <para>Eyoü s†̎ juu lej† tsou tsa s†̎i tiní nita tsako' mixii chima tsamakaloo lej†̎ tsou lekö mukuu.</para>
+            <para>Eyoü sɨ̎ juu lejɨ tsou tsa sɨ̎i tiní nita tsako' mixii chima tsamakaloo lejɨ̎ tsou lekö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="22">
       <title>Jau Kiú Tü (22).</title>
-      <para>Lej†̎ tsou tsa chitoo je̱ juu, ti jmos í le kö ni jmä le kö mukuu lej†̎ tsou tsa tö' köní t†̎ kau', makou's ne tsamakaloo ekio tsou lii jmo' re kio juu.</para>
+      <para>Lejɨ̎ tsou tsa chitoo je̱ juu, ti jmos í le kö ni jmä le kö mukuu lejɨ̎ tsou tsa tö' köní tɨ̎ kau', makou's ne tsamakaloo ekio tsou lii jmo' re kio juu.</para>
    </article>
    <article number="23">
       <title>Jau Kiú Ne (23).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ ta, tsamakaloo takios köre mojoo mayoü s†̎ lej†̎ tsou in† kö juu lej†̎ tsou sia makat† ta.</para>
+            <para>Lejɨ̎ tsou tɨ̎ ta, tsamakaloo takios köre mojoo mayoü sɨ̎ lejɨ̎ tsou inɨ kö juu lejɨ̎ tsou sia makatɨ ta.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou t†̎ jmos ta ne emamäs kuré lej†̎ rüs ne jmos í ta̱ kios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ jmos ta ne emamäs kuré lejɨ̎ rüs ne jmos í ta̱ kios.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou tsa dijmo ta t†̎ kau' kuré mojoo ku's tsa rüs, mojoo lisiä lej†̎ tsou tsa kua mukuu, mojoo e mayaäs e jua' nio̱ tsou.</para>
+            <para>Lejɨ̎ tsou tsa dijmo ta tɨ̎ kau' kuré mojoo ku's tsa rüs, mojoo lisiä lejɨ̎ tsou tsa kua mukuu, mojoo e mayaäs e jua' nio̱ tsou.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou t†̎ jupií jna tiös kö jau lej†̎ tsou mojoo kö re jmos í kios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ jupií jna tiös kö jau lejɨ̎ tsou mojoo kö re jmos í kios.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
       <title>Jau Kiú Kiü (24).</title>
-      <para>Lej†̎ tsou t†̎ jupií mojoo jñaas kö wua mojoo ñaas ta kios na makaloös.</para>
+      <para>Lejɨ̎ tsou tɨ̎ jupií mojoo jñaas kö wua mojoo ñaas ta kios na makaloös.</para>
    </article>
    <article number="25">
-      <title>Jau Kiú Ñaa Ras† Kö (25).</title>
+      <title>Jau Kiú Ñaa Rasɨ Kö (25).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ kö ní mojoo kuas re lej†̎ tsa rüs, mojoo jmos í ni s†̍'s kios ne mojoo kuas re, ne mojoo ku're, mojoo t†̎ muküs, ne mojoo t†̎ nei' kios, mojoo t†̎ m†̎, ne mojoo li t†̎ lej†̎ ijmoü' nei' kios, mojoo t†̎ kö mixii ekuee jupií kia' mojoo kues m†̎ nakalasö, naka jü ñikuo' e mamäs kia'nü, na kuas na masadö sia lii jmo' ta e mamäs kia nü.</para>
+            <para>Lejɨ̎ tsou tɨ̎ kö ní mojoo kuas re lejɨ̎ tsa rüs, mojoo jmos í ni sɨ̍'s kios ne mojoo kuas re, ne mojoo ku're, mojoo tɨ̎ muküs, ne mojoo tɨ̎ nei' kios, mojoo tɨ̎ mɨ̎, ne mojoo li tɨ̎ lejɨ̎ ijmoü' nei' kios, mojoo tɨ̎ kö mixii ekuee jupií kia' mojoo kues mɨ̎ nakalasö, naka jü ñikuo' e mamäs kia'nü, na kuas na masadö sia lii jmo' ta e mamäs kia nü.</para>
          </listitem>
          <listitem>
-            <para>Tïma ni' jo̱ns t†̎ ejmo' í ne̱ s†̎. Lej†̎ daü pí tsa lisiä ekio tsa di gï kuo t†̎ kure jmo' í.</para>
+            <para>Tïma ni' jo̱ns tɨ̎ ejmo' í ne̱ sɨ̎. Lejɨ̎ daü pí tsa lisiä ekio tsa di gï kuo tɨ̎ kure jmo' í.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="26">
-      <title>Jau Kiú Jñi Ras† Kö (26).</title>
+      <title>Jau Kiú Jñi Rasɨ Kö (26).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ e'es mixii. Tasia mamäs kio t†̎ kati kut†̍s xii kios, kati kuis xii jue' nasia kau' isia' xii ko's.</para>
+            <para>Lejɨ̎ tsou tɨ̎ e'es mixii. Tasia mamäs kio tɨ̎ kati kutɨ̍s xii kios, kati kuis xii jue' nasia kau' isia' xii ko's.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou lit†̎ xii tsa ñi̱ t†̎ ne tsamakaloo e ñis a le t†̍ le kö mukuu ne lej†̎ tsa le' jumeï, ne jmos laj†̍ ta sia le kö mukuu mojoo sia tï tsou.</para>
+            <para>Lejɨ̎ tsou litɨ̎ xii tsa ñi̱ tɨ̎ ne tsamakaloo e ñis a le tɨ̍ le kö mukuu ne lejɨ̎ tsa le' jumeï, ne jmos lajɨ̍ ta sia le kö mukuu mojoo sia tï tsou.</para>
          </listitem>
          <listitem>
-            <para>Jmeïs t†̎ inios e xii nios kio jös.</para>
+            <para>Jmeïs tɨ̎ inios e xii nios kio jös.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="27">
-      <title>Jau Kiú Kió Ras† Kö (27).</title>
+      <title>Jau Kiú Kió Rasɨ Kö (27).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou t†̎ ejmos tsamakalo̱ö ne jmos le inios juu kios mojoo li†̍s ta majau mojoo chä lej†̎ i t†̍s juu kios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ ejmos tsamakalo̱ö ne jmos le inios juu kios mojoo liɨ̍s ta majau mojoo chä lejɨ̎ i tɨ̍s juu kios.</para>
          </listitem>
          <listitem>
-            <para>Lej†̎ tsou t†̎ ne kues jupií t†̎ ne tsamakaloö, lej†̍ tsou lijmos xii kio jmeï kios.</para>
+            <para>Lejɨ̎ tsou tɨ̎ ne kues jupií tɨ̎ ne tsamakaloö, lejɨ̍ tsou lijmos xii kio jmeï kios.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
       <title>Jau Kiú Jñaa (28).</title>
-      <para>Lej†̎ tsou t†̎ jmos kö jau le kö mukuu ne t†̎ tsamakaloo lej†̎ chitoo ni mixii mojoo jmoo jna isoo ta.</para>
+      <para>Lejɨ̎ tsou tɨ̎ jmos kö jau le kö mukuu ne tɨ̎ tsamakaloo lejɨ̎ chitoo ni mixii mojoo jmoo jna isoo ta.</para>
    </article>
    <article number="29">
-      <title>Jau Kiú Ñü Ras† Kö (29).</title>
+      <title>Jau Kiú Ñü Rasɨ Kö (29).</title>
       <orderedlist>
          <listitem>
-            <para>Lej†̎ tsou esiaa ejmos ta tiní juu kios lii jmos ta tsamakaloo ne elijmos kio lej†̎ tsou.</para>
+            <para>Lejɨ̎ tsou esiaa ejmos ta tiní juu kios lii jmos ta tsamakaloo ne elijmos kio lejɨ̎ tsou.</para>
          </listitem>
          <listitem>
-            <para>E t†̎ tsou tsamakaloo̱ ne lej†̎ tsou esi†̎ ja̱ le chitoo ni mixii mojoo t†̎ jupií ne t†̎ tsamakaloo, lej†̎ tsou í mojoo re tiö tsou.</para>
+            <para>E tɨ̎ tsou tsamakaloo̱ ne lejɨ̎ tsou esiɨ̎ ja̱ le chitoo ni mixii mojoo tɨ̎ jupií ne tɨ̎ tsamakaloo, lejɨ̎ tsou í mojoo re tiö tsou.</para>
          </listitem>
          <listitem>
-            <para>Le t†̎ tsamakaloo tasia lijmos isia' le chitoo ni mixii le kö mukuu.</para>
+            <para>Le tɨ̎ tsamakaloo tasia lijmos isia' le chitoo ni mixii le kö mukuu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
       <title>Jau Kiú Kia (30).</title>
-      <para>Tasia chitoo ni mixii tasia li jmos jna isia' ijoo jmo'jna la chitoo ilaa mojoo kuee jupií ne t†̎ le kö ni jmä kö cha̱ tsou, elijmos ta mojoo lijmos kö tsó̱ lej†̎ t†̎ ne makaloo le ichitoo ni mixii la.</para>
+      <para>Tasia chitoo ni mixii tasia li jmos jna isia' ijoo jmo'jna la chitoo ilaa mojoo kuee jupií ne tɨ̎ le kö ni jmä kö cha̱ tsou, elijmos ta mojoo lijmos kö tsó̱ lejɨ̎ tɨ̎ ne makaloo le ichitoo ni mixii la.</para>
    </article>
 </udhr>


### PR DESCRIPTION
- replace † by ɨ
- replace U+030E by U+0308, as used on other vowels.
- remove U+030D on ɨ, which served as tittle on †

Note: this is most likely another Chinantec language as Chiltepec Chinantec is nearly estinct according to [Ethnologue](https://www.ethnologue.com/language/csa/) but [the Chinanteco UDHR translation OHCHR page](https://www.ohchr.org/en/human-rights/universal-declaration/translations/chinanteco) indicates the language had 1000 speakers in 1990.