### PR TITLE
Northern Kissi [kqs]: replace O, E by ɔ, ɛ when adequate

### DIFF
--- a/data/udhr/udhr_kqs.xml
+++ b/data/udhr/udhr_kqs.xml
@@ -6,244 +6,244 @@
    <title>Yonda ciendo le hakilan wanaciewo</title>
    <preamble>
       <title>Dimilacioo</title>
-      <para>Te o wa pa, a laalando a num pla le yugoo faw o pulalen ni a haki ndaa vellaa velle, o wana tEEnbu le o, ndu cio tumdo ni le malnOndo, a senduwo, a kol Muloo sOlaa o ciendo ni.</para>
-      <para>Te o wa pa, ma kE wanathyéyEyi cEucEuvo kEwo sina, a kEwo ndu hEnando, ndu nOn hunOn a delOOcoo ni mi wanda faMa, ndu tosa saboo wElE ni mi wada sOla kul Muloo, le waa ba daa cio le sanga wOOdo ciolabaa.</para>
-      <para>Te o wa pE, a wanaceu cEucEuvo a kangalan ngo cio ni, o kon ni mE mi lingden nde wa bendaa ni tOngdo kOOli pindo, kon nOn tosaa ni mi wanda kEE nufia le nda pla i kayi, ma tosa baara o lingden o kul ndyadaa ni.</para>
-      <para>Te o wa pE, mi naan kenan balan le bEndaa ciOOluo lOyOO lingdo tE,</para>
-      <para>Te o wa pE, lingi cio o “ONU” bEnda bEndo ni, mi ndaa yOngu diyom daa a n’cio wanathyéo kadaa, ma ciEucEu ndu mi siingu wanapOnOn a wanalanOn vellaa velle,</para>
-      <para>Te o wa pE, aa lingi cio lenni nda, nda cEl pE a ‘‘ONU’’ kO, le bEnda ciEdo ho, a waa ba numdo cio a biyOO a balan tan ciOn pE,</para>
-      <para>Te o wa pE, a yian pilOO nan nOn ni, le hakilan dan a wa ba numdo thyo o tosaa mEE naan dimi yE,</para>
-      <para>BOOngian kundaa</para>
-      <para>yiyan kudaa wanda tu, a ME lingdon le cio nufia wo o benda naan ni, miyonda kon wa bE tu le bol, le lOO lOO, o kon kOOly mE mi bEtu kinding a kalando kOOly a kaala kEndan kOOly le hakilan lan a malaa thEuthEuvo le kOlan laci, o kon ni mi bEElen le tosang o lingi nayini a lingy kEkE cio o kundaa kalaa ni.</para>
-      <para>Yonda ciEdo le hakilan wanaciEwo</para>
+      <para>Te o wa pa, a laalando a num pla le yugoo faw o pulalen ni a haki ndaa vellaa velle, o wana tɛɛnbu le o, ndu cio tumdo ni le malnɔndo, a senduwo, a kol Muloo sɔlaa o ciendo ni.</para>
+      <para>Te o wa pa, ma kɛ wanathyéyɛyi cɛucɛuvo kɛwo sina, a kɛwo ndu hɛnando, ndu nɔn hunɔn a delɔɔcoo ni mi wanda faMa, ndu tosa saboo wɛlɛ ni mi wada sɔla kul Muloo, le waa ba daa cio le sanga wɔɔdo ciolabaa.</para>
+      <para>Te o wa pɛ, a wanaceu cɛucɛuvo a kangalan ngo cio ni, o kon ni mɛ mi lingden nde wa bendaa ni tɔngdo kɔɔli pindo, kon nɔn tosaa ni mi wanda kɛɛ nufia le nda pla i kayi, ma tosa baara o lingden o kul ndyadaa ni.</para>
+      <para>Te o wa pɛ, mi naan kenan balan le bɛndaa ciɔɔluo lɔyɔɔ lingdo tɛ,</para>
+      <para>Te o wa pɛ, lingi cio o “ONU” bɛnda bɛndo ni, mi ndaa yɔngu diyom daa a n’cio wanathyéo kadaa, ma ciɛucɛu ndu mi siingu wanapɔnɔn a wanalanɔn vellaa velle,</para>
+      <para>Te o wa pɛ, aa lingi cio lenni nda, nda cɛl pɛ a ‘‘ONU’’ kɔ, le bɛnda ciɛdo ho, a waa ba numdo cio a biyɔɔ a balan tan ciɔn pɛ,</para>
+      <para>Te o wa pɛ, a yian pilɔɔ nan nɔn ni, le hakilan dan a wa ba numdo thyo o tosaa mɛɛ naan dimi yɛ,</para>
+      <para>Bɔɔngian kundaa</para>
+      <para>yiyan kudaa wanda tu, a Mɛ lingdon le cio nufia wo o benda naan ni, miyonda kon wa bɛ tu le bol, le lɔɔ lɔɔ, o kon kɔɔly mɛ mi bɛtu kinding a kalando kɔɔly a kaala kɛndan kɔɔly le hakilan lan a malaa thɛuthɛuvo le kɔlan laci, o kon ni mi bɛɛlen le tosang o lingi nayini a lingy kɛkɛ cio o kundaa kalaa ni.</para>
+      <para>Yonda ciɛdo le hakilan wanaciɛwo</para>
    </preamble>
    <article number="1">
-      <title>TOng 1</title>
-      <para>wanda tu cio ME pilOO o wolOO ni, le waa o ba ndOO cio, o bEElen kenando ni, o tOngdo ni, bEtu nOn yiyando a kullo, o kon ni naan tu dua mim maalyan kalapilOyEyi ni.</para>
+      <title>Tɔng 1</title>
+      <para>wanda tu cio Mɛ pilɔɔ o wolɔɔ ni, le waa o ba ndɔɔ cio, o bɛɛlen kenando ni, o tɔngdo ni, bɛtu nɔn yiyando a kullo, o kon ni naan tu dua mim maalyan kalapilɔyɛyi ni.</para>
    </article>
    <article number="2">
-      <title>TOng 2</title>
-      <para>wana wana dua mo wa tOng cEucEu wanaciE wo bEngu, mEE mEE suu numdo ciE, mEE mEE diyallonumdo ciE, mEE mEE tOng le lingdo ciE, a naa naa nda wellu numda ciE.</para>
+      <title>Tɔng 2</title>
+      <para>wana wana dua mo wa tɔng cɛucɛu wanaciɛ wo bɛngu, mɛɛ mɛɛ suu numdo ciɛ, mɛɛ mɛɛ diyallonumdo ciɛ, mɛɛ mɛɛ tɔng le lingdo ciɛ, a naa naa nda wellu numda ciɛ.</para>
   </article>
    <article number="3">
-      <title>TOng 3</title>
-      <para>kul wana wana dua mo sOla kidaa, le waa wElE o ba dOO cio, le boten ndOlencEucEu vo.</para>
+      <title>Tɔng 3</title>
+      <para>kul wana wana dua mo sɔla kidaa, le waa wɛlɛ o ba dɔɔ cio, le boten ndɔlencɛucɛu vo.</para>
    </article>
    <article number="4">
-      <title>TOng 4</title>
-      <para>wana wana dua mo wa ciElen bEngu le, mo wa sawo wana celen bEngu le, o kon ni ciElen nde kuunang a yulalen dOlen wElE.</para>
+      <title>Tɔng 4</title>
+      <para>wana wana dua mo wa ciɛlen bɛngu le, mo wa sawo wana celen bɛngu le, o kon ni ciɛlen nde kuunang a yulalen dɔlen wɛlɛ.</para>
    </article>
    <article number="5">
-      <title>TOng 5</title>
-      <para>wOulen kE kE duama andun wanaciEu ciEyo le, y pala du woo, y dOOniMa wElE ndu woo.</para>
+      <title>Tɔng 5</title>
+      <para>wɔulen kɛ kɛ duama andun wanaciɛu ciɛyo le, y pala du woo, y dɔɔniMa wɛlɛ ndu woo.</para>
    </article>
    <article number="6">
-      <title>TOng 6</title>
-      <para>n’dua minsina wanaciEyEyi le wana wana o tOngdo hOlba ba o wa pE.</para>
+      <title>Tɔng 6</title>
+      <para>n’dua minsina wanaciɛyɛyi le wana wana o tɔngdo hɔlba ba o wa pɛ.</para>
    </article>
    <article number="7">
-      <title>TOng 7</title>
-      <para>bEtu cio biyOO pilO ni tOngdo hOl, mo mala wElE bEtu, wanna fisa wElE cian tE ndo hOl.</para>
+      <title>Tɔng 7</title>
+      <para>bɛtu cio biyɔɔ pilɔ ni tɔngdo hɔl, mo mala wɛlɛ bɛtu, wanna fisa wɛlɛ cian tɛ ndo hɔl.</para>
    </article>
    <article number="8">
-      <title>TOng 8</title>
-      <para>bEtu dua mo bi seyi tOng le lindo, te o pilan num pE tana pE, te o cio kOlan ngo nEyo cioo le.</para>
+      <title>Tɔng 8</title>
+      <para>bɛtu dua mo bi seyi tɔng le lindo, te o pilan num pɛ tana pɛ, te o cio kɔlan ngo nɛyo cioo le.</para>
    </article>
    <article number="9">
-      <title>TOng 9</title>
-      <para>wanna bi tyandO lende naa le, ma loyEi ndu o kaaso ni, ma tow ndu o lingi nduwEy ni fuu.</para>
+      <title>Tɔng 9</title>
+      <para>wanna bi tyandɔ lende naa le, ma loyɛi ndu o kaaso ni, ma tow ndu o lingi nduwɛy ni fuu.</para>
    </article>
    <article number="10">
-      <title>TOng 10</title>
-      <para>kangalan mEE mi suwEyi wanacieo wa o diyandaa, mo wa wagba diiyo kOOly o ciEyi kitiyo ni, le haki dO a yaala dO sina.</para>
+      <title>Tɔng 10</title>
+      <para>kangalan mɛɛ mi suwɛyi wanacieo wa o diyandaa, mo wa wagba diiyo kɔɔly o ciɛyi kitiyo ni, le haki dɔ a yaala dɔ sina.</para>
    </article>
    <article number="11">
-      <title>TOng 11</title>
+      <title>Tɔng 11</title>
       <orderedlist>
          <listitem>
-            <para>Wana wana tOngdo by o sikaa kOOly, wana kon dua binu maa i nduEyi cio lening te, haan ma kero yabayo kerung, ma ke ndu diiyo te o tyo kon te ma yaala du.</para>
+            <para>Wana wana tɔngdo by o sikaa kɔɔly, wana kon dua binu maa i nduɛyi cio lening te, haan ma kero yabayo kerung, ma ke ndu diiyo te o tyo kon te ma yaala du.</para>
          </listitem>
          <listitem>
-            <para>Wana wana biinun pE tOng paando tEEmbuo kOOly, wana doi ma biinun ndu le kity tOng sEnEyo le, pEEgu biyOOdo dua mo yiu haki kiti paando le.</para>
+            <para>Wana wana biinun pɛ tɔng paando tɛɛmbuo kɔɔly, wana doi ma biinun ndu le kity tɔng sɛnɛyo le, pɛɛgu biyɔɔdo dua mo yiu haki kiti paando le.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
-      <title>TOng 12</title>
-      <para>wanna doi ma lOyi o suEyi playe ni te, o wa pE suEyi pulalen ndOlen pE, o wa pE sun dO vinan wElE pE, a sun lungdo wElE pE, o doi ma sOla kul palaa kE kE o lan ning te, te kun wa pE, tOngdo doi kada bE tu o sun wa lende ni.</para>
+      <title>Tɔng 12</title>
+      <para>wanna doi ma lɔyi o suɛyi playe ni te, o wa pɛ suɛyi pulalen ndɔlen pɛ, o wa pɛ sun dɔ vinan wɛlɛ pɛ, a sun lungdo wɛlɛ pɛ, o doi ma sɔla kul palaa kɛ kɛ o lan ning te, te kun wa pɛ, tɔngdo doi kada bɛ tu o sun wa lende ni.</para>
    </article>
    <article number="13">
-      <title>TOng 13</title>
+      <title>Tɔng 13</title>
       <orderedlist>
          <listitem>
-            <para>kOlan nga hOnOO kumbiya wagba le bE tu o lingden ni, naa naa nyEnan wElE pE a doi ma thianun don.</para>
+            <para>kɔlan nga hɔnɔɔ kumbiya wagba le bɛ tu o lingden ni, naa naa nyɛnan wɛlɛ pɛ a doi ma thianun don.</para>
          </listitem>
          <listitem>
-            <para>Wana wan cio o ba dOO cio le fagandO o lingden ali o wa lingi nduEyi pE, ma muugu wElE o ndu lo.</para>
+            <para>Wana wan cio o ba dɔɔ cio le fagandɔ o lingden ali o wa lingi nduɛyi pɛ, ma muugu wɛlɛ o ndu lo.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="14">
-      <title>TOng 14</title>
+      <title>Tɔng 14</title>
       <orderedlist>
          <listitem>
-            <para>Te sOn delOOcio ying pE, a tiuba ma kuwE o lingy cielen ni le kidaa sOlaa, wanaa kan dua ma kEE num te.</para>
+            <para>Te sɔn delɔɔcio ying pɛ, a tiuba ma kuwɛ o lingy cielen ni le kidaa sɔlaa, wanaa kan dua ma kɛɛ num te.</para>
          </listitem>
          <listitem>
-            <para>tOngdo ho cio le wando ho le, o tEEbu tOng lingi ndoEyi mo sOndan.</para>
+            <para>tɔngdo ho cio le wando ho le, o tɛɛbu tɔng lingi ndoɛyi mo sɔndan.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="15">
-      <title>TOng 15</title>
+      <title>Tɔng 15</title>
       <orderedlist>
          <listitem>
-            <para>bE tu dua mo wa o lingden ma polelingdo,</para>
+            <para>bɛ tu dua mo wa o lingden ma polelingdo,</para>
          </listitem>
          <listitem>
-            <para>wanna kuuna du polelingdo sOlaa le, o kon ni, o tiwba mo sOlaa poleling dole lingden ciElen.</para>
+            <para>wanna kuuna du polelingdo sɔlaa le, o kon ni, o tiwba mo sɔlaa poleling dole lingden ciɛlen.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="16">
-      <title>TOng 16</title>
+      <title>Tɔng 16</title>
       <orderedlist>
          <listitem>
-            <para>te wOsilan felegbOaa tiiya pE nOw pE, a tiwba nang o nOw ni, suwEyi suu hElyo kon ni te a suwEyi diinayi wElE cio kon ni te, le lan bE tu thyo vellaa velle tOngdo laci,</para>
+            <para>te wɔsilan felegbɔaa tiiya pɛ nɔw pɛ, a tiwba nang o nɔw ni, suwɛyi suu hɛlyo kon ni te a suwɛyi diinayi wɛlɛ cio kon ni te, le lan bɛ tu thyo vellaa velle tɔngdo laci,</para>
          </listitem>
          <listitem>
-            <para>nOw djinun niya MOn tEn te fo mi la ciyEl,</para>
+            <para>nɔw djinun niya Mɔn tɛn te fo mi la ciyɛl,</para>
          </listitem>
          <listitem>
-            <para>yungoo, naa pla tEn ngo fula ni nOw kOOli, lelan n’dua mi gbagba ndaa o lingden ni</para>
+            <para>yungoo, naa pla tɛn ngo fula ni nɔw kɔɔli, lelan n’dua mi gbagba ndaa o lingden ni</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="17">
-      <title>TOng 17</title>
+      <title>Tɔng 17</title>
       <orderedlist>
          <listitem>
-            <para>wanna wa pE kundaa tEn pE, te o cio kon te, mo wa wanapilEyEi ni, o nOn hakiyo le sOla le ndu pla.</para>
+            <para>wanna wa pɛ kundaa tɛn pɛ, te o cio kon te, mo wa wanapilɛyɛi ni, o nɔn hakiyo le sɔla le ndu pla.</para>
          </listitem>
          <listitem>
-            <para>ME wanna dua ma puu ndoo ba kafalan cio le.</para>
+            <para>Mɛ wanna dua ma puu ndoo ba kafalan cio le.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="18">
-      <title>TOng 18</title>
-      <para>bEtu nOn hakiyo le waa o ba dO cio, le yiyando, le kOlo sOlaa le diinayo mE o hEnang yE, o nOn wElE hakiyo le Yiyan dO a diina dO kon singafila mE o yEnang yE,o kundaa tEn kaa mo wanapilEYEi ni.</para>
+      <title>Tɔng 18</title>
+      <para>bɛtu nɔn hakiyo le waa o ba dɔ cio, le yiyando, le kɔlo sɔlaa le diinayo mɛ o hɛnang yɛ, o nɔn wɛlɛ hakiyo le Yiyan dɔ a diina dɔ kon singafila mɛ o yɛnang yɛ,o kundaa tɛn kaa mo wanapilɛYɛi ni.</para>
    </article>
    <article number="19">
-      <title>TOng 19</title>
-      <para>bEtu nOn hakiyo le waa malaa ni le Yiyan dO ciOOmuo, kon thyOm ni ma ciyogi doi ma bii ndu le o Yiyan ndO kon te, kon cio sEngindo wElE babba a nEilan siyaama mo tang wElE pEEngu le lingdon tu.</para>
+      <title>Tɔng 19</title>
+      <para>bɛtu nɔn hakiyo le waa malaa ni le Yiyan dɔ ciɔɔmuo, kon thyɔm ni ma ciyogi doi ma bii ndu le o Yiyan ndɔ kon te, kon cio sɛngindo wɛlɛ babba a nɛilan siyaama mo tang wɛlɛ pɛɛngu le lingdon tu.</para>
    </article>
    <article number="20">
-      <title>TOng 20</title>
+      <title>Tɔng 20</title>
       <orderedlist>
           <listitem>
-            <para>bEtu nOn hakiyo le bcngiyando a kunda kul Muloo tosa.</para>
+            <para>bɛtu nɔn hakiyo le bcngiyando a kunda kul Muloo tosa.</para>
          </listitem>
          <listitem>
-            <para>Wanna doi mo luwEyi ciandO o kundaa ni kalan te.</para>
+            <para>Wanna doi mo luwɛyi ciandɔ o kundaa ni kalan te.</para>
          </listitem>
      </orderedlist>
    </article>
    <article number="21">
-      <title>TOng 21</title>
+      <title>Tɔng 21</title>
       <orderedlist>
          <listitem>
-            <para>bEtu nOn hakiyo waa masa le lingdo, te o cio kon te, mo wa le wana dO YEnangdo,</para>
+            <para>bɛtu nɔn hakiyo waa masa le lingdo, te o cio kon te, mo wa le wana dɔ Yɛnangdo,</para>
          </listitem>
          <listitem>
-            <para>hOOlelingdo tu nOn hakiyo le waa baara le lingdo ni velle velle,</para>
+            <para>hɔɔlelingdo tu nɔn hakiyo le waa baara le lingdo ni velle velle,</para>
          </listitem>
          <listitem>
-            <para>Yomu sariya lingdOn le cio landaaa YEnang hOOlelingdOn, ndaa doi mi ndaa ciOm Yiyan da kEndan o laalando kO, a wote wElE kO.</para>
+            <para>Yomu sariya lingdɔn le cio landaaa Yɛnang hɔɔlelingdɔn, ndaa doi mi ndaa ciɔm Yiyan da kɛndan o laalando kɔ, a wote wɛlɛ kɔ.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="22">
-      <title>TOng 22</title>
-      <para>lingden faw doi mo cEucEu hOOalelingda faw, o suEyi sOlaa kO, o suEyi gbawEyiyo kO, o suEyi dEnE sina kO. cEucEu le lingden le le, o ME dO sOlaa ni ngo fula ni, a ME ndO sOlaa o baaralan ni a lingi thelenda tayin.</para>
+      <title>Tɔng 22</title>
+      <para>lingden faw doi mo cɛucɛu hɔɔalelingda faw, o suɛyi sɔlaa kɔ, o suɛyi gbawɛyiyo kɔ, o suɛyi dɛnɛ sina kɔ. cɛucɛu le lingden le le, o Mɛ dɔ sɔlaa ni ngo fula ni, a Mɛ ndɔ sɔlaa o baaralan ni a lingi thelenda tayin.</para>
    </article>
    <article number="23">
-      <title>TOng 23</title>
+      <title>Tɔng 23</title>
       <orderedlist>
          <listitem>
-            <para>bEtu doi mo sOla baara, mo tosa baara o hEmang du wo o kul Muloo ni, o doi mo cEu cEu wanaa le lingda le baara le pEngdo ciolabaa.</para>
+            <para>bɛtu doi mo sɔla baara, mo tosa baara o hɛmang du wo o kul Muloo ni, o doi mo cɛu cɛu wanaa le lingda le baara le pɛngdo ciolabaa.</para>
          </listitem>
          <listitem>
-            <para>baaralan la cio ME pilolan kan duama nO saralan pilE lan le wanaa baara.</para>
+            <para>baaralan la cio Mɛ pilolan kan duama nɔ saralan pilɛ lan le wanaa baara.</para>
          </listitem>
          <listitem>
             <para>baara dua mo sarang, sara dua mo tiu wanaabaara a Mugu do,</para>
          </listitem>
          <listitem>
-            <para>wanaa baara faw nOn hakiyo le kundaa tosa, o mala wanaa baara wa, ma veelu ndu ‘‘ syndicat ’’o puuriE ni.</para>
+            <para>wanaa baara faw nɔn hakiyo le kundaa tosa, o mala wanaa baara wa, ma veelu ndu ‘‘ syndicat ’’o puuriɛ ni.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
-      <title>TOng 24</title>
-      <para>bEtu nOn hakiyo le pEngiyo o baara ni, mo pisulu baara kOOli a baara tosa pEEngo bEngu, ma sara ndu wElE pEngu pEngiyo bEngu, o nda weelu naa “congé”</para>
+      <title>Tɔng 24</title>
+      <para>bɛtu nɔn hakiyo le pɛngiyo o baara ni, mo pisulu baara kɔɔli a baara tosa pɛɛngo bɛngu, ma sara ndu wɛlɛ pɛngu pɛngiyo bɛngu, o nda weelu naa “congé”</para>
    </article>
    <article number="25">
-      <title>TOng 25</title>
+      <title>Tɔng 25</title>
       <orderedlist>
          <listitem>
-            <para>bEtu nOn hakiyo le sew sOlaa o cEucEu yugu dOO, le ciEn kEndOO tosaa, le kEndiya, MEdiya, worolan, cEyi lOlaa, a ndu pla dandaa dOwOO. Te naa komalang pE, baara le pEngdo pE, a balafondoyEi kE kE komalang pE, a doi ma sOla malaa.</para>
+            <para>bɛtu nɔn hakiyo le sew sɔlaa o cɛucɛu yugu dɔɔ, le ciɛn kɛndɔɔ tosaa, le kɛndiya, Mɛdiya, worolan, cɛyi lɔlaa, a ndu pla dandaa dɔwɔɔ. Te naa komalang pɛ, baara le pɛngdo pɛ, a balafondoyɛi kɛ kɛ komalang pɛ, a doi ma sɔla malaa.</para>
          </listitem>
          <listitem>
-            <para>Komisaa a cErEgbE nOn hakiyo le malaa sOlaa, hOO welun pE o nOw ni kaa o ciEmOO ni, haki pilO nda nOn ni o cEuciEuvo ni.</para>
+            <para>Komisaa a cɛrɛgbɛ nɔn hakiyo le malaa sɔlaa, hɔɔ welun pɛ o nɔw ni kaa o ciɛmɔɔ ni, haki pilɔ nda nɔn ni o cɛuciɛuvo ni.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="26">
-      <title>TOng 26</title>
+      <title>Tɔng 26</title>
       <orderedlist>
          <listitem>
-            <para>bEtu nOn hakiyo kalando, mi kalan kon doi mo wa wElE fondoo, le kalan tasoo a o din dOO, kalan la lan doi ma kangalan le bEtu. Karantaa le dEnE sina, karantaa le baara pEEkuwo a karantaa bEndo o thyo lan tu cioocioo wo, cio malaa le bEtu vellaa velle,</para>
+            <para>bɛtu nɔn hakiyo kalando, mi kalan kon doi mo wa wɛlɛ fondoo, le kalan tasoo a o din dɔɔ, kalan la lan doi ma kangalan le bɛtu. Karantaa le dɛnɛ sina, karantaa le baara pɛɛkuwo a karantaa bɛndo o thyo lan tu cioocioo wo, cio malaa le bɛtu vellaa velle,</para>
          </listitem>
          <listitem>
-            <para>karantaa doi mo mala wana thyeu, le wanayEyi nduEyi yowOO lathi, le waa o ba ndO cio yowOO laci, o doi mo tosa saboo le nEyOn wOOndo malOO, mo tosa wElE mi MiyE a canjan luEyi ceedo ni suulan tE, diinalan wanda tE, ma mala wElE kundaa bEndo “ONU” le bEnda lOyOO o ciEdo ni,</para>
+            <para>karantaa doi mo mala wana thyeu, le wanayɛyi nduɛyi yowɔɔ lathi, le waa o ba ndɔ cio yowɔɔ laci, o doi mo tosa saboo le nɛyɔn wɔɔndo malɔɔ, mo tosa wɛlɛ mi Miyɛ a canjan luɛyi ceedo ni suulan tɛ, diinalan wanda tɛ, ma mala wɛlɛ kundaa bɛndo “ONU” le bɛnda lɔyɔɔ o ciɛdo ni,</para>
          </listitem>
          <listitem>
-            <para>bEtu nOn hakiyo le hOOa ndua malOO o karanta ni o hEnan nda pE</para>
+            <para>bɛtu nɔn hakiyo le hɔɔa ndua malɔɔ o karanta ni o hɛnan nda pɛ</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="27">
-      <title>TOng 27</title>
+      <title>Tɔng 27</title>
       <orderedlist>
          <listitem>
-            <para>bEtu nOn hakiyo le waa o sun dEnE sina le lingdon ni mE mE o wa, mo o soling wElE tOnOOn.</para>
+            <para>bɛtu nɔn hakiyo le waa o sun dɛnɛ sina le lingdon ni mɛ mɛ o wa, mo o soling wɛlɛ tɔnɔɔn.</para>
          </listitem>
          <listitem>
-            <para>bEtu nOn hakiyo le tOnOn baara ndO le yiyanndo, a baara ndO le diyallo, a baara ndO kE kE o dEnE sinaa ni ma cEucEu lan le nduvo.</para>
+            <para>bɛtu nɔn hakiyo le tɔnɔn baara ndɔ le yiyanndo, a baara ndɔ le diyallo, a baara ndɔ kɛ kɛ o dɛnɛ sinaa ni ma cɛucɛu lan le nduvo.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
-      <title>TOng 28</title>
-      <para>bEtu nOn hakiyo le tOngdan naan yOda nua, mi le tosang o wanayEi ni o lingden ni a lingi tuwEi wElE ni.</para>
+      <title>Tɔng 28</title>
+      <para>bɛtu nɔn hakiyo le tɔngdan naan yɔda nua, mi le tosang o wanayɛi ni o lingden ni a lingi tuwɛi wɛlɛ ni.</para>
    </article>
    <article number="29">
-      <title>TOng 29</title>
+      <title>Tɔng 29</title>
       <orderedlist>
          <listitem>
-            <para>te wancEu nOn pE hakiyo pE, laalan wElE ma o nOn o cio le tosaa kangalan,</para>
+            <para>te wancɛu nɔn pɛ hakiyo pɛ, laalan wɛlɛ ma o nɔn o cio le tosaa kangalan,</para>
          </listitem>
          <listitem>
-            <para>a wa pE baara haki numdo tosaa pE, a dua ma lo tOngdo kOOli, haliko ma pilan wana thelen tana le,</para>
+            <para>a wa pɛ baara haki numdo tosaa pɛ, a dua ma lo tɔngdo kɔɔli, haliko ma pilan wana thelen tana le,</para>
          </listitem>
          <listitem>
-            <para>tOngda la lan dua mo kera o yiyan celen thyoo le, te o cio yiyan kunda bEndo “ONU” o le.</para>
+            <para>tɔngda la lan dua mo kera o yiyan celen thyoo le, te o cio yiyan kunda bɛndo “ONU” o le.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
-      <title>TOng 30</title>
-      <para>wanna nOn ma yOOmu le, lingi kE kE nOn ma yOOmu le, le fulaa a neyi celen o tEEbu tOngdan lan naan yOda lan.</para>
+      <title>Tɔng 30</title>
+      <para>wanna nɔn ma yɔɔmu le, lingi kɛ kɛ nɔn ma yɔɔmu le, le fulaa a neyi celen o tɛɛbu tɔngdan lan naan yɔda lan.</para>
    </article>
 </udhr>

--- a/data/udhr/udhr_kqs.xml
+++ b/data/udhr/udhr_kqs.xml
@@ -11,7 +11,7 @@
       <para>Te o wa pɛ, a wanaceu cɛucɛuvo a kangalan ngo cio ni, o kon ni mɛ mi lingden nde wa bendaa ni tɔngdo kɔɔli pindo, kon nɔn tosaa ni mi wanda kɛɛ nufia le nda pla i kayi, ma tosa baara o lingden o kul ndyadaa ni.</para>
       <para>Te o wa pɛ, mi naan kenan balan le bɛndaa ciɔɔluo lɔyɔɔ lingdo tɛ,</para>
       <para>Te o wa pɛ, lingi cio o “ONU” bɛnda bɛndo ni, mi ndaa yɔngu diyom daa a n’cio wanathyéo kadaa, ma ciɛucɛu ndu mi siingu wanapɔnɔn a wanalanɔn vellaa velle,</para>
-      <para>Te o wa pɛ, aa lingi cio lenni nda, nda cɛl pɛ a ‘‘ONU’’ kɔ, le bɛnda ciɛdo ho, a waa ba numdo cio a biyɔɔ a balan tan ciɔn pɛ,</para>
+      <para>Te o wa pɛ, aa lingi cio lenni nda, nda cɛl pɛ a “ONU” kɔ, le bɛnda ciɛdo ho, a waa ba numdo cio a biyɔɔ a balan tan ciɔn pɛ,</para>
       <para>Te o wa pɛ, a yian pilɔɔ nan nɔn ni, le hakilan dan a wa ba numdo thyo o tosaa mɛɛ naan dimi yɛ,</para>
       <para>Bɔɔngian kundaa</para>
       <para>yiyan kudaa wanda tu, a Mɛ lingdon le cio nufia wo o benda naan ni, miyonda kon wa bɛ tu le bol, le lɔɔ lɔɔ, o kon kɔɔly mɛ mi bɛtu kinding a kalando kɔɔly a kaala kɛndan kɔɔly le hakilan lan a malaa thɛuthɛuvo le kɔlan laci, o kon ni mi bɛɛlen le tosang o lingi nayini a lingy kɛkɛ cio o kundaa kalaa ni.</para>


### PR DESCRIPTION
- replace O, E by ɔ, ɛ when adequate (not in ONU)
- replace ‘‘ONU’’ by “ONU”