### PR TITLE
Update ethnologue.com and sil.org ISO639-3 URLs

### DIFF
--- a/unicode.org/xsl/indexpage.xsl
+++ b/unicode.org/xsl/indexpage.xsl
@@ -118,7 +118,7 @@ function getUrlParameter(sParam)
   <row>
     <entry><xsl:value-of select='@f'/></entry>
     <entry>
-       <ulink url='http://www.ethnologue.com/show_language.asp?code={@iso639-3}'><xsl:value-of select='@n'/></ulink>
+       <ulink url='http://www.ethnologue.com/language/{@iso639-3}/'><xsl:value-of select='@n'/></ulink>
      </entry>
 
     <entry><xsl:value-of select='@region'/></entry>

--- a/unicode.org/xsl/indexpage.xsl
+++ b/unicode.org/xsl/indexpage.xsl
@@ -123,7 +123,7 @@ function getUrlParameter(sParam)
 
     <entry><xsl:value-of select='@region'/></entry>
 
-    <entry><ulink url='http://www.sil.org/ISO639-3/documentation.asp?id={@iso639-3}'><xsl:value-of select='@iso639-3'/></ulink></entry>
+    <entry><ulink url='http://https://iso639-3.sil.org/code/{@iso639-3}'><xsl:value-of select='@iso639-3'/></ulink></entry>
 
     <entry><xsl:value-of select='@iso15924'/></entry>
 


### PR DESCRIPTION
Ethnologue.com URLs have moved, for example http://www.ethnologue.com/show_language.asp?code=mah is now http://www.ethnologue.com/language/mah/.

SIL ISO639-3 URLs have moved, for example http://www.sil.org/ISO639-3/documentation.asp?id=mah is now https://iso639-3.sil.org/code/mah.