### PR TITLE
pcd: replace e° by e̊

### DIFF
--- a/data/udhr/udhr_pcd.xml
+++ b/data/udhr/udhr_pcd.xml
@@ -9,19 +9,19 @@
       <para>considèrant qu' fåte dè k'nohe èt d' rèspècter lès dreûts d' l'ome, ènn' a dès cis qu' s'ont avili å pont d' brutålizer l' s-ôtes d'ine manîre scandaleûse po l' consyince di l'ûmånité qui l's-omes adon èspèrèt dè viker d'tot leû coûr èn-on monde wice qu'i sèrît turtos lîbes dè parler èt d' creûre, dilîbèrés qu'i sont dèl tèreûr èt dèl mizére, insi qu'il a stu prôclamé ;</para>
       <para>considèrant qu' s'on louke dè fwèrci l'ome a s'chèrvi dèl rèvole come dièrin mwèyin disconte di l'abus dèl pouhance èt d' l'assèrvih'mint, i fåt-st-apreume qu'on rèdjime di dreût garantih lès dreûts d' l'ome ;</para>
       <para>considèrant qu' lès peûpes dès Nåcions-Unèyes ont, è leû Lwè d' fondåcion, prôclamé 'ne fèye di pus' leû fwè d'vins lès dreûts naturéls di l'ome, d'vins l'dignité èt l' valeûr dès-omes èt dès feumes, qu'il ont rézoû d' favorizer l' progrès sociål èt d' mète è plèce dès mèyeûsès condicions po viker avou 'ne pus grande lîbèrté ;</para>
-      <para>considèrant qu' lès-Etats mambes s'ont ègadjî po-z-assûrer vre°ymint tot costé, avou l'e°de di l'Organizåcion, li rèspèt dès dreûts d' l'ome èt d'sès naturélès lîbèrtés ;</para>
+      <para>considèrant qu' lès-Etats mambes s'ont ègadjî po-z-assûrer vre̊ymint tot costé, avou l'e̊de di l'Organizåcion, li rèspèt dès dreûts d' l'ome èt d'sès naturélès lîbèrtés ;</para>
       <para>considèrant qu'i s' fåt turtos mète d'acwérd so l' significåcion d' cès dreûts èt d' ces lîbèrtés-la s'on vout rèyålizer on tél ègadjemint ;</para>
       <para>considèrant qu'il è-st-important d'ècorèdjî totes lès nåcions a s'aconter todi mîs eune l'ôte,</para>
-      <para>li jènèrale Assimble°ye</para>
-      <para>prôclame cisse Dèclaråcion dès dreûts d' l'ome come riprézintant lès comeunès valeûrs di l'ûmånité qui tos lès peûpes èt totes lès nåcions d'vront sayî d' tote leû fwèce dè mète èn-oûve afîs' qui totes lèes djins èt totes lès sôciètés, tot-z-avant tofér cisse Dèclaråcion èl tièsse si fwèrcihesse, avou lès mwèyins d' l'ansègnemint èt d' l'éducåcion, dè fèé crèhe li rèspèt d' cès dreûts èt lîbèrtés èt d'ènn' assûrer, gråce a dès-adjincenèdjes todi pus nèts å lève° nacionål èt internacionål, li rik'nohance èt l'aplicåcion è monde ètîr èt d'ine rèyéle manîre, ot'tant è-mé lès populåcions dès-Etats mambes qu' è-mé lès cisses dès tères qui sont d'zos leû k'dûhance.</para>
+      <para>li jènèrale Assimble̊ye</para>
+      <para>prôclame cisse Dèclaråcion dès dreûts d' l'ome come riprézintant lès comeunès valeûrs di l'ûmånité qui tos lès peûpes èt totes lès nåcions d'vront sayî d' tote leû fwèce dè mète èn-oûve afîs' qui totes lèes djins èt totes lès sôciètés, tot-z-avant tofér cisse Dèclaråcion èl tièsse si fwèrcihesse, avou lès mwèyins d' l'ansègnemint èt d' l'éducåcion, dè fèé crèhe li rèspèt d' cès dreûts èt lîbèrtés èt d'ènn' assûrer, gråce a dès-adjincenèdjes todi pus nèts å lève̊ nacionål èt internacionål, li rik'nohance èt l'aplicåcion è monde ètîr èt d'ine rèyéle manîre, ot'tant è-mé lès populåcions dès-Etats mambes qu' è-mé lès cisses dès tères qui sont d'zos leû k'dûhance.</para>
    </preamble>
    <article number="1">
       <title>prumî årtike</title>
-      <para>Tos lès-omes vinèt å monde lîbes èt égåls po çou qu'èst d' leû dignité èt d' leûs dreûts. Leû re°zon èt leû consyince elzî fe°t on d'vwér di s'kidûre inte di zèle come dès frès</para>
+      <para>Tos lès-omes vinèt å monde lîbes èt égåls po çou qu'èst d' leû dignité èt d' leûs dreûts. Leû re̊zon èt leû consyince elzî fe̊t on d'vwér di s'kidûre inte di zèle come dès frès</para>
    </article>
    <article number="2">
       <title>årt II.</title>
-      <para>Chaskeun' pout prétinde a tos lès dreûts èt a totes lès lîbèrtés qui sont chal prôclamés, sins qu'on prinse astème, par ègzimpe, a s' race, a s' coleûr, a s' nateûre d'ome ou d'feume, a s' lingadje, a sès crwèyinces, a sès-îdèyes so l' politique ou so tot l'minme cwè, al contre°ye ou al famile di wice qu' i provint, a s' fôrtune, a s' lignèdje, brèf a cwè qui ç' seûye.</para>
+      <para>Chaskeun' pout prétinde a tos lès dreûts èt a totes lès lîbèrtés qui sont chal prôclamés, sins qu'on prinse astème, par ègzimpe, a s' race, a s' coleûr, a s' nateûre d'ome ou d'feume, a s' lingadje, a sès crwèyinces, a sès-îdèyes so l' politique ou so tot l'minme cwè, al contre̊ye ou al famile di wice qu' i provint, a s' fôrtune, a s' lignèdje, brèf a cwè qui ç' seûye.</para>
       <para>E d' pus', nouk ni deût påti d' çou qu'on pout pinser dè gouvèrnémint di s' patrèye, di si-administråcion, di s' condicion rapôrt as-ôtes payis, qu'èle seûye souvèrinne ou soumîse d'ine manîre ou d' l'ôte.</para>
    </article>
    <article number="3">
@@ -34,7 +34,7 @@
    </article>
    <article number="5">
       <title>årt V.</title>
-      <para>Nouk ni pout-èsse mètou al torteûre, savadjmint maltre°tî èt avili, swè-dîzant dèl pûni.</para>
+      <para>Nouk ni pout-èsse mètou al torteûre, savadjmint maltre̊tî èt avili, swè-dîzant dèl pûni.</para>
    </article>
    <article number="6">
       <title>årt VI.</title>
@@ -42,43 +42,43 @@
    </article>
    <article number="7">
       <title>årt VII.</title>
-      <para>Tos lès-omes sont égåals divant li lwè, qu'èlzès deût protéjer, sins nole préfèrince po onk ou po l'ôte, çou qu' sèreût contre°re al prézinte Déclaråcion Parèlièmint, li lwè 'lzès deût protéjer conte lès cis qu' vôrît ric'mander 'ne téle sôr di préfèrince.</para>
+      <para>Tos lès-omes sont égåals divant li lwè, qu'èlzès deût protéjer, sins nole préfèrince po onk ou po l'ôte, çou qu' sèreût contre̊re al prézinte Déclaråcion Parèlièmint, li lwè 'lzès deût protéjer conte lès cis qu' vôrît ric'mander 'ne téle sôr di préfèrince.</para>
    </article>
    <article number="8">
       <title>årt VIII.</title>
-      <para>Chaskeun' deût-èsse vrèyemint lîbe d'atre°re divant lès djudjes di s' payis tot lès cis qu'adjihèt conte lès me°sses dreûts rik'nohous d'vins l'constitucion ou d'vins li lwè.</para>
+      <para>Chaskeun' deût-èsse vrèyemint lîbe d'atre̊re divant lès djudjes di s' payis tot lès cis qu'adjihèt conte lès me̊sses dreûts rik'nohous d'vins l'constitucion ou d'vins li lwè.</para>
    </article>
    <article number="9">
       <title>årt IX.</title>
-      <para>Nouk ni pout, sins nole bone re°zon, èsse arèsté, rèssèré, ou bin tchèssî foû di s' payis.</para>
+      <para>Nouk ni pout, sins nole bone re̊zon, èsse arèsté, rèssèré, ou bin tchèssî foû di s' payis.</para>
    </article>
    <article number="10">
       <title>årt X.</title>
-      <para>Tot l'monde a parèlièmint l' dreût d' ple°tî s' cåse divant on tribunål qui seûye lîbe èt sins parti-pris. Et li d'vwèr dè tribunål, ci sèrè d' décîder so lès dreûts èt so lès obligåcions dès ple°tieûs ou bin d' djudjî si l' acuzé èst coupåbe ou ènocint di çou qu'on l' amète.</para>
+      <para>Tot l'monde a parèlièmint l' dreût d' ple̊tî s' cåse divant on tribunål qui seûye lîbe èt sins parti-pris. Et li d'vwèr dè tribunål, ci sèrè d' décîder so lès dreûts èt so lès obligåcions dès ple̊tieûs ou bin d' djudjî si l' acuzé èst coupåbe ou ènocint di çou qu'on l' amète.</para>
    </article>
    <article number="11">
       <title>årt XI.</title>
       <orderedlist>
          <listitem>
-            <para>Tot quî è-st-acuzé d'on dèlit deût-èsse supôzé ènocint disqu'a tant qu'il åye situ publiquemint djudjî èt rik'nohou coupåbe d'après li lwè èt so condicion qu' il åye situ tot-a fe°t lîbe di s' disfinde.</para>
+            <para>Tot quî è-st-acuzé d'on dèlit deût-èsse supôzé ènocint disqu'a tant qu'il åye situ publiquemint djudjî èt rik'nohou coupåbe d'après li lwè èt so condicion qu' il åye situ tot-a fe̊t lîbe di s' disfinde.</para>
          </listitem>
          <listitem>
-            <para>Nouk ni pout-èsse condanné po dès fe°ts ou po dès måquemints qu' n' alît nin conte li dreût nacionål ou internacionål å moumint qu' ont stu comètous. Et tot fî parèy ni pout-i èsse condanné pus deûremint qu'i l'åreût stu å minme moumint, d'après li lwè.</para>
+            <para>Nouk ni pout-èsse condanné po dès fe̊ts ou po dès måquemints qu' n' alît nin conte li dreût nacionål ou internacionål å moumint qu' ont stu comètous. Et tot fî parèy ni pout-i èsse condanné pus deûremint qu'i l'åreût stu å minme moumint, d'après li lwè.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>årt XII.</title>
-      <para>Il èst disfindou d' s'intrimète sins re°zon d'vins lès-afe°res d'ine saquî ou di s' famile, di brokî è s' mohone, di nahî d'vins lès lètes qu'i r'çût ou qu'il èvôye. Il èst disfindou d' l' ac'sûre divins si-oneûr ou d'vins s' réputåcion. A d' fåt d' çoula, chaskeun' a l' dreût d' rèclamer l'pretècsion dès lwès.</para>
+      <para>Il èst disfindou d' s'intrimète sins re̊zon d'vins lès-afe̊res d'ine saquî ou di s' famile, di brokî è s' mohone, di nahî d'vins lès lètes qu'i r'çût ou qu'il èvôye. Il èst disfindou d' l' ac'sûre divins si-oneûr ou d'vins s' réputåcion. A d' fåt d' çoula, chaskeun' a l' dreût d' rèclamer l'pretècsion dès lwès.</para>
    </article>
    <article number="13">
       <title>årt XIII.</title>
       <orderedlist>
          <listitem>
-            <para>Chaskeun' a l' dreût d' cotî avå s' payis come i lî ple°t èt d' s'adjîstrer tot wice qu'il a îdèye.</para>
+            <para>Chaskeun' a l' dreût d' cotî avå s' payis come i lî ple̊t èt d' s'adjîstrer tot wice qu'il a îdèye.</para>
          </listitem>
          <listitem>
-            <para>Chaskeun'a ossi l' dreût d' cwiter tot l' minme qué payîs, minme li sonk, èt d' î rintrer qwand-i lî ple°t.</para>
+            <para>Chaskeun'a ossi l' dreût d' cwiter tot l' minme qué payîs, minme li sonk, èt d' î rintrer qwand-i lî ple̊t.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -86,10 +86,10 @@
       <title>årt XIV.</title>
       <orderedlist>
          <listitem>
-            <para>Si an cas qu' i-åreût 'ne pèrsécussion, on a todi l' dreût d' cwèri a s' ahouter èt di s'se°wer a l' ètrindjîr, s'il atome insi.</para>
+            <para>Si an cas qu' i-åreût 'ne pèrsécussion, on a todi l' dreût d' cwèri a s' ahouter èt di s'se̊wer a l' ètrindjîr, s'il atome insi.</para>
          </listitem>
          <listitem>
-            <para>On n' si pout prévaleûr d' on tèl dreût s'on-èst porsuvou po des fe°tes cléremint provés qui vont conte lès lwès ou conte lès-îdèyes dès Nåciones-Unèyes.</para>
+            <para>On n' si pout prévaleûr d' on tèl dreût s'on-èst porsuvou po des fe̊tes cléremint provés qui vont conte lès lwès ou conte lès-îdèyes dès Nåciones-Unèyes.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -100,7 +100,7 @@
             <para>Chaskeun' a dreût a 'ne nacionålité.</para>
          </listitem>
          <listitem>
-            <para>Nouk ni pout-èsse, sins nole bone re°zon, spani di s' nacionålité ni di s'dreût d'ènnè candjî.</para>
+            <para>Nouk ni pout-èsse, sins nole bone re̊zon, spani di s' nacionålité ni di s'dreût d'ènnè candjî.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -114,7 +114,7 @@
             <para>On n' pout marier in-ome èt 'ne feume s' i n' sèrît nin d'acwèrd.</para>
          </listitem>
          <listitem>
-            <para>Li nateûre a fe°t dèl famile li fondemint dèl sôcièté èt l' socièté ossi bin qu' l' Etat ont l' dvwér dèl protéjer.</para>
+            <para>Li nateûre a fe̊t dèl famile li fondemint dèl sôcièté èt l' socièté ossi bin qu' l' Etat ont l' dvwér dèl protéjer.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -125,13 +125,13 @@
             <para>Chaskeun' èst lîbe d' aveûr dè bin, seûye-t-i d'a sonk tot seû, seûye-t-i è comunôté.</para>
          </listitem>
          <listitem>
-            <para>Nouk ni pout-èsse, sins nole bone re°zon, dispouyî di s'bin.</para>
+            <para>Nouk ni pout-èsse, sins nole bone re̊zon, dispouyî di s'bin.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="18">
       <title>årt XVIII.</title>
-      <para>Chaskeun' èst me°sse di sès-îdèyes, di s' consyinca, di s' rilidjon. Coula vout dîre qu'il èst lîbe dè régler s' vèye so sès prôpés-îdèyes èt so s' rilidjon, tot seû ou bin avou dès-ôtes, è s' mohone come å d' foû, avou l'ansègnemint, lès pratiques, lès-ûzances èt lès cèrèmon'rèyes qui l'agrèyèt.</para>
+      <para>Chaskeun' èst me̊sse di sès-îdèyes, di s' consyinca, di s' rilidjon. Coula vout dîre qu'il èst lîbe dè régler s' vèye so sès prôpés-îdèyes èt so s' rilidjon, tot seû ou bin avou dès-ôtes, è s' mohone come å d' foû, avou l'ansègnemint, lès pratiques, lès-ûzances èt lès cèrèmon'rèyes qui l'agrèyèt.</para>
    </article>
    <article number="19">
       <title>årt XIX.</title>
@@ -158,7 +158,7 @@
             <para>Chaskeun' ås minmès condiciones, pout prétinde a on posse divins lès-administråcions.</para>
          </listitem>
          <listitem>
-            <para>Lès me°sses dèl nåcion ni d'vèt leû pouvwèr qu'al vol'té dè peûpe, téle qu'èle si done a k'nohe ås-élècsions, qu'i fåt èmantchî d'vins l'dreût dè djeû, å moumint volou, avou l'sufraje ûnivèrsél èt lès minmes dreûts po turtos. Et s' fåt-i co qu' chaskeun' si pôye rètrôk'ler po vôter sècrètemint, a mons qu' on-imådjine ine ôte manîre dè rèspècter parèlièmint l' lîbèrté dè vôtant.</para>
+            <para>Lès me̊sses dèl nåcion ni d'vèt leû pouvwèr qu'al vol'té dè peûpe, téle qu'èle si done a k'nohe ås-élècsions, qu'i fåt èmantchî d'vins l'dreût dè djeû, å moumint volou, avou l'sufraje ûnivèrsél èt lès minmes dreûts po turtos. Et s' fåt-i co qu' chaskeun' si pôye rètrôk'ler po vôter sècrètemint, a mons qu' on-imådjine ine ôte manîre dè rèspècter parèlièmint l' lîbèrté dè vôtant.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -170,13 +170,13 @@
       <title>årt XXIII.</title>
       <orderedlist>
          <listitem>
-            <para>Chaskeun' a l' dreût d'ovrer èt d' fé l' mestî qu' lî ple°t. Et s'èl deût-on adègnî so l' ovrèdje tot lî mètant dès condicions qu' sèyèsse djusses ét dûhåves. El fåt ossi assûrer conte li chômèdje.</para>
+            <para>Chaskeun' a l' dreût d'ovrer èt d' fé l' mestî qu' lî ple̊t. Et s'èl deût-on adègnî so l' ovrèdje tot lî mètant dès condicions qu' sèyèsse djusses ét dûhåves. El fåt ossi assûrer conte li chômèdje.</para>
          </listitem>
          <listitem>
             <para>Po l' minme payèle, tos l's-ovrîs ont dreût al minme påye, sins nole prèfèrince.</para>
          </listitem>
          <listitem>
-            <para>Tot quî qu' oûveûre deût lèver l' sale°re qui lî r'vint èt qu' deût lî pèrmète, lu èt s' famile, dè miner l' vicåaèye d'ine one°te djint. Et s'il atome insi, c' è-st-al sôcièté d' mète çou qu' pôreût måquer.</para>
+            <para>Tot quî qu' oûveûre deût lèver l' sale̊re qui lî r'vint èt qu' deût lî pèrmète, lu èt s' famile, dè miner l' vicåaèye d'ine one̊te djint. Et s'il atome insi, c' è-st-al sôcièté d' mète çou qu' pôreût måquer.</para>
          </listitem>
          <listitem>
             <para>On a todi l' dreût dè r'djonde on sindicat ou di s'mète a saqwant' po 'nn' èmantchî onk.</para>
@@ -194,7 +194,7 @@
             <para>Tot l' monde a dreût a 'ne vicårèye qui lî pèrmète dè sognî s' santé èt s' confôrt come lès cis di s' famile, par ègzimpe ôpo çou qu'èst d' magnî, di s' moussî, d' s'adjîstrern di s' fé médî èt d' saqwants chèrvices di sôcièté qu' on n' s' è pout passer. Lès chômeurs, lès malådes, lès mèsbrudjîs, lès vèfs èt lès vèves, lès veyès djints, lès cis qu'on pièrdou leû gangnèdje mågré zèls ont dreût al sécurité.</para>
          </listitem>
          <listitem>
-            <para>Lès méres di famile èt l's-ènfants ont-st-a preume li dreût d' èsse e°dîs èt assistés. Tos l's-éfants, qu' i sèyèsse vinou a monde divins l' marièdje ou foû, ont l' minme dreût al sécurité sociaåle.</para>
+            <para>Lès méres di famile èt l's-ènfants ont-st-a preume li dreût d' èsse e̊dîs èt assistés. Tos l's-éfants, qu' i sèyèsse vinou a monde divins l' marièdje ou foû, ont l' minme dreût al sécurité sociaåle.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -205,7 +205,7 @@
             <para>Tot l' monde deût poleûr fé dès-ètudes, èt çoula gråtis', dè mons po çou qu' èst dès bassès scoles. I fåt-st-èmantchî on pô tot costé dès scoles tèchniques èt profèssionéles. Tant qu'ås hôtès scoles, èlzès fåt drovi parèlièmint a turtos d'après lès mèrites.</para>
          </listitem>
          <listitem>
-            <para>Li d'vwèr dès me°sses di scole, c'èst d' fé frudjî lès capåcités d' chaskeun' èt d' mî fé rèspècter lès dreûts d' l' ome èt lès prumîrès lîbèrtés. C' è-st-ossi d' aminer lès djints d'totes lès nåcions, di totes lès races, di totes lès r' lidjons a s' mî comprinde, a s' mî supwèrter, a s' mî inmer. C'è-st anfin d'e°dî lès Nåcions-Unèyes a todi mî ovrer po qui l' monde wåde li påye.</para>
+            <para>Li d'vwèr dès me̊sses di scole, c'èst d' fé frudjî lès capåcités d' chaskeun' èt d' mî fé rèspècter lès dreûts d' l' ome èt lès prumîrès lîbèrtés. C' è-st-ossi d' aminer lès djints d'totes lès nåcions, di totes lès races, di totes lès r' lidjons a s' mî comprinde, a s' mî supwèrter, a s' mî inmer. C'è-st anfin d'e̊dî lès Nåcions-Unèyes a todi mî ovrer po qui l' monde wåde li påye.</para>
          </listitem>
          <listitem>
             <para>C'è-stèa preume ås parints d'tchûzi l' mèyeûse sicole po leûs-èfants.</para>
@@ -216,7 +216,7 @@
       <title>årt XXVII.</title>
       <orderedlist>
          <listitem>
-            <para>Rapôrt al cultûre, chaque mambe dèl comunôté deût poleûr profiter d' tot çou qui' i s' passe, an'mirer lès-oûves dès-årtisses, prinde pårt ås-invancions dès savants èt a leûs binfe°ts.</para>
+            <para>Rapôrt al cultûre, chaque mambe dèl comunôté deût poleûr profiter d' tot çou qui' i s' passe, an'mirer lès-oûves dès-årtisses, prinde pårt ås-invancions dès savants èt a leûs binfe̊ts.</para>
          </listitem>
          <listitem>
             <para>Lès savants, lès scriyeûs, lès-årtisses ont l' dreût d'èsse disfindous s' on vôreût fé twert a leû gangnèdje ou bin a leû dignité.</para>
@@ -231,7 +231,7 @@
       <title>årt XXIX.</title>
       <orderedlist>
          <listitem>
-            <para>Chaskeun' n'a dès-obligåcions qu'avou l' comunôté qu'èl le°t tot-a fe°t lîbe dè mète èn-oûve sès capåcités.</para>
+            <para>Chaskeun' n'a dès-obligåcions qu'avou l' comunôté qu'èl le̊t tot-a fe̊t lîbe dè mète èn-oûve sès capåcités.</para>
          </listitem>
          <listitem>
             <para>Li lwè a seûle li pouwèr dè rastrinde lès dreûts èt lès lîbèrtés d' chaskeun', dè moumint qu' c'èst po fé rik'nohe èt rèspècter lès dreûts èt lès lîbèrtés dès-ôtes, po prézèrver l' moråalité, l' tranquilité dès dhins èt l' binåhiste d' turtos d'vins 'ne sôcièté d' dèmocråtes.</para>


### PR DESCRIPTION
The e̊ is used in the extended Feller spelling for Walloon and Picard, for example in the [_Atlas linguistique de Wallonie_](https://alw.uliege.be/alw/?alw_volume=4&alw_page=12&alw_mode=explore#alw-page-section).