### PR TITLE
udhr_idu: replace peculiar characters

### DIFF
--- a/data/udhr/udhr_idu.xml
+++ b/data/udhr/udhr_idu.xml
@@ -5,74 +5,74 @@
 <udhr iso639-3="idu" xml:lang="idu" key="idu" n="Idoma"  dir="ltr" iso15924="Latn" xmlns="http://www.unicode.org/udhr">
    <title>OJE KA K’ĘLA KƆDAH NƆCĘ LĘ AA</title>
    <preamble>
-      <title>Okwaję kęla.</title>
-      <para>Higbęgͻ ma, oje ͻda ni w’ ͻkpͻci męml oj’ojinlę kͻdah nͻcę lę abͻ keinu lipu kipͻnu unu w’okwaję ko labͻ lei nu męml’ępͻ ͻkpakpa aa, tik ͻgbͻtu lipu kęcę nya duu ma, higbęgͻ ma, akwula n męml’ okpo dͻdah gͻcę iby’ͻda ni wei kunu n męmy’ olukpafyu ikpo waję, ęgę ni labͻ b’ocaięla jͻcę kipu k’ͻtu ͻcę baję. Ohigbacę ni la lęcę nya ki labahi kolabͻ lei wa ipu gͻkͻ okęla-uwa, męml’okpohilice męml’oђmataję hukpo oya ta ti k’oyͻda tei kabͻ nęw’acę idͻka ђwule, higb’ęgͻ ma ͻcęgba nęnęhi kokwͻcę baję męml’o yͻcę tͻha kͻma ko yͻ. Ɔ wei gunu kojęgͻbu koyͻ ip’ͻinę oya męml’ͻmpa kunu. hibi kͻha nę, United Nations lohili ni tu ohibi k’ͻgbͻtu ko yͻ lęi aję duu je taję fyę ikwęi ͻdah nͻcę lę aa, hibi ko jęgͻbu, męml’ojima tig oyei ͻlam k’ͻcę go yͻ ipu olabͻ lei nu. Igwu igwu kacę lęlęwa cę ko bͻha yukͻlͻ męml’United Nations ohigb ojęgͻbu kͻdah ab’ͻcę ti k’aђ leiђ ma kͻcę ni wͻda agbanjala.</para>
-      <para>Baba nya, higbęgͻ ma, igwu kacę lęb General Assembly, kͻdah ni kl’abͻ kͻcę nya kl’ęcę pee ohigb’ͻcę duu nę kͻ je ͻda ni wikwęi kͻdah ni yip’abͻ ͻcę duu ip’ęcę nya ma, ti gęgę ni jiko oby’ͻ yukͻlͻ lęi kaję ęikaję. Higbͻ ma ͻwuђkpę kͻcę duu lęi kaję duu gͻ bi by’ęla kͻdah kabͻ gͻcę nę ip’ͻtu gunu, ęla nya hͻi kͻ yei ip’ͻtu ͻcę dę nębͻ ki yͻ męml’ogbͻtu ip’ęcę nę ma.</para>
+      <title>Okwajɛ kɛla.</title>
+      <para>Higbɛgɔ ma, oje ɔda ni w’ ɔkpɔci mɛml oj’ojinlɛ kɔdah nɔcɛ lɛ abɔ keinu lipu kipɔnu unu w’okwajɛ ko labɔ lei nu mɛml’ɛpɔ ɔkpakpa aa, tik ɔgbɔtu lipu kɛcɛ nya duu ma, higbɛgɔ ma, akwula n mɛml’ okpo dɔdah gɔcɛ iby’ɔda ni wei kunu n mɛmy’ olukpafyu ikpo wajɛ, ɛgɛ ni labɔ b’ocaiɛla jɔcɛ kipu k’ɔtu ɔcɛ bajɛ. Ohigbacɛ ni la lɛcɛ nya ki labahi kolabɔ lei wa ipu gɔkɔ okɛla-uwa, mɛml’okpohilice mɛml’oŋmatajɛ hukpo oya ta ti k’oyɔda tei kabɔ nɛw’acɛ idɔka ŋwule, higb’ɛgɔ ma ɔcɛgba nɛnɛhi kokwɔcɛ bajɛ mɛml’o yɔcɛ tɔha kɔma ko yɔ. Ɔ wei gunu kojɛgɔbu koyɔ ip’ɔinɛ oya mɛml’ɔmpa kunu. hibi kɔha nɛ, United Nations lohili ni tu ohibi k’ɔgbɔtu ko yɔ lɛi ajɛ duu je tajɛ fyɛ ikwɛi ɔdah nɔcɛ lɛ aa, hibi ko jɛgɔbu, mɛml’ojima tig oyei ɔlam k’ɔcɛ go yɔ ipu olabɔ lei nu. Igwu igwu kacɛ lɛlɛwa cɛ ko bɔha yukɔlɔ mɛml’United Nations ohigb ojɛgɔbu kɔdah ab’ɔcɛ ti k’aŋ leiŋ ma kɔcɛ ni wɔda agbanjala.</para>
+      <para>Baba nya, higbɛgɔ ma, igwu kacɛ lɛb General Assembly, kɔdah ni kl’abɔ kɔcɛ nya kl’ɛcɛ pee ohigb’ɔcɛ duu nɛ kɔ je ɔda ni wikwɛi kɔdah ni yip’abɔ ɔcɛ duu ip’ɛcɛ nya ma, ti gɛgɛ ni jiko oby’ɔ yukɔlɔ lɛi kajɛ ɛikajɛ. Higbɔ ma ɔwuŋkpɛ kɔcɛ duu lɛi kajɛ duu gɔ bi by’ɛla kɔdah kabɔ gɔcɛ nɛ ip’ɔtu gunu, ɛla nya hɔi kɔ yei ip’ɔtu ɔcɛ dɛ nɛbɔ ki yɔ mɛml’ogbɔtu ip’ɛcɛ nɛ ma.</para>
    </preamble>
    <article number="1">
       <title>OKA 1</title>
-      <para>Ęgę ni modudu acę kęcę nya bęcę ęhehi aa ,hibi ęgͻ ma acę duu jonjilę ipu kocęgba nͻcę cęgba męml’ojonjilę ipu ͻdah ni yabͻ ͻcę nya. Odudu acę kwu ђwule ml’ohili otu męml’ocai kęla jͻcę ͻha ni yipu ͻtu ͻcę aa, higbͻ ma ͻcę higbo yͻda męml’ ͻmpa gunu lę bͻinę nu ma.</para>
+      <para>Ęgɛ ni modudu acɛ kɛcɛ nya bɛcɛ ɛhehi aa ,hibi ɛgɔ ma acɛ duu jonjilɛ ipu kocɛgba nɔcɛ cɛgba mɛml’ojonjilɛ ipu ɔdah ni yabɔ ɔcɛ nya. Odudu acɛ kwu ŋwule ml’ohili otu mɛml’ocai kɛla jɔcɛ ɔha ni yipu ɔtu ɔcɛ aa, higbɔ ma ɔcɛ higbo yɔda mɛml’ ɔmpa gunu lɛ bɔinɛ nu ma.</para>
    </article>
    <article number="2">
       <title>OKA 2</title>
-      <para>Odudu acę ciko wei ko lͻdah k’abͻ ei wa męml’olabͻ lei wa ipu ko jęla gͻdah kͻcę aa kla klęcę, g’okͻ ęyęyi lę b’ędͻ gacę ma , ina gͻkp’iye kͻcę, ͻcęnya aman k’ͻcęnyilͻ, ichi ichi oka, ogb’Owoico ęgba aman utu utu kacę, ębę ni m’ͻcę ta kwęę ͻda ęgę nya duu nę kͻ ma ko yͻ.</para>
-      <para>ͻha kunu, okͻ ęyęyi duu kͻ yͻ ikwęi abͻ nikpei ͻcę wa kwęę olufyu męml’ ojęgͻbu kęi aję nͻcę ђma aa, gͻcokwu węi aję ni labͻ lei wa, ni kpͻtu ce wa, ęiaję ni labͻ lei wa n, kwęę ipu gͻda ęyęyi ęgę nya.</para>
+      <para>Odudu acɛ ciko wei ko lɔdah k’abɔ ei wa mɛml’olabɔ lei wa ipu ko jɛla gɔdah kɔcɛ aa kla klɛcɛ, g’okɔ ɛyɛyi lɛ b’ɛdɔ gacɛ ma , ina gɔkp’iye kɔcɛ, ɔcɛnya aman k’ɔcɛnyilɔ, ichi ichi oka, ogb’Owoico ɛgba aman utu utu kacɛ, ɛbɛ ni m’ɔcɛ ta kwɛɛ ɔda ɛgɛ nya duu nɛ kɔ ma ko yɔ.</para>
+      <para>ɔha kunu, okɔ ɛyɛyi duu kɔ yɔ ikwɛi abɔ nikpei ɔcɛ wa kwɛɛ olufyu mɛml’ ojɛgɔbu kɛi ajɛ nɔcɛ ŋma aa, gɔcokwu wɛi ajɛ ni labɔ lei wa, ni kpɔtu ce wa, ɛiajɛ ni labɔ lei wa n, kwɛɛ ipu gɔda ɛyɛyi ɛgɛ nya.</para>
   </article>
    <article number="3">
       <title>OKA 3</title>
-      <para>Ododu acę lͻdah ko yei ęgę duu, męml’oђmat’aję h’o bl’baję ta męml’ogbikwęi ͻcę dodu ęgę duu jojinlę.</para>
+      <para>Ododu acɛ lɔdah ko yei ɛgɛ duu, mɛml’oŋmat’ajɛ h’o bl’bajɛ ta mɛml’ogbikwɛi ɔcɛ dodu ɛgɛ duu jojinlɛ.</para>
    </article>
    <article number="4">
       <title>OKA4</title>
-      <para>Ododu acę cika yipu ͻfyę oya n, aw’ͻfyę męml’ͻyi gͻfyę ota wei ko yͻ ip’acę kęcę nya n, ęgę duu nͻ cokwu lę.</para>
+      <para>Ododu acɛ cika yipu ɔfyɛ oya n, aw’ɔfyɛ mɛml’ɔyi gɔfyɛ ota wei ko yɔ ip’acɛ kɛcɛ nya n, ɛgɛ duu nɔ cokwu lɛ.</para>
    </article>
    <article number="5">
       <title>OKA5</title>
-      <para>Ͻlᴐhi ki ml’ͻcę duu ta j’owe aman bḛ k’ogbobaję, aman bḛ k’alachi, aman bḛ k’ocai kęla lͻcę fy’ḛgḛ nęla ͻma lę n.</para>
+      <para>Ɔlᴐhi ki ml’ɔcɛ duu ta j’owe aman bɛ k’ogbobajɛ, aman bɛ k’alachi, aman bɛ k’ocai kɛla lɔcɛ fy’ɛgɛ nɛla ɔma lɛ n.</para>
    </article>
    <article number="6">
       <title>OKA6</title>
-      <para>Odudu acę wei ko jͻkwͻkwęi gḛlḛ nya kaini ęgę duu nͻcę yͻ, ͻyͻ ip’abͻ k’ͻdah ni yᴐ gbaję ęgę nͻ yͻ aa.</para>
+      <para>Odudu acɛ wei ko jɔkwɔkwɛi gɛlɛ nya kaini ɛgɛ duu nɔcɛ yɔ, ɔyɔ ip’abɔ k’ɔdah ni yᴐ gbajɛ ɛgɛ nɔ yɔ aa.</para>
    </article>
    <article number="7">
       <title>OKA7</title>
-      <para>Odudu acę j’onjilę ikpei k’ͻdah,ḛgᴐ ma nͻdah ciko gb’ikwęi ͻcę duu nę j ‘onjilę aa. Ɔdah ciko wikwęi ͻcę ohigb’ͻda nᴐcę ya ni wei kᴐda nͻdah ka n aman ko y’ͻda ni yᴐ bu tęla k’ͻdah, aman bḛ k’oyᴐda bei kͻdah ni yab’ͻcę nya .</para>
+      <para>Odudu acɛ j’onjilɛ ikpei k’ɔdah,ɛgᴐ ma nɔdah ciko gb’ikwɛi ɔcɛ duu nɛ j ‘onjilɛ aa. Ɔdah ciko wikwɛi ɔcɛ ohigb’ɔda nᴐcɛ ya ni wei kᴐda nɔdah ka n aman ko y’ɔda ni yᴐ bu tɛla k’ɔdah, aman bɛ k’oyᴐda bei kɔdah ni yab’ɔcɛ nya .</para>
    </article>
    <article number="8">
       <title>OKA8</title>
-      <para>Ohigb’iko nͻcę duu ibḛi k’ͻdah ni yip’abͻ-nu nͻdah kęi ajḛ-nu je ta lᴐ aa , aw’okępͻ k’ͻdah cika cai kḛla jᴐcḛ ḛgᴐ ma.</para>
+      <para>Ohigb’iko nɔcɛ duu ibɛi k’ɔdah ni yip’abɔ-nu nɔdah kɛi ajɛ-nu je ta lᴐ aa , aw’okɛpɔ k’ɔdah cika cai kɛla jᴐcɛ ɛgᴐ ma.</para>
    </article>
    <article number="9">
       <title>OKA9</title>
-      <para>Odudu acḛ duu iciko bei kipu kinu-agba aman bḛ okw’ͻcę dudu igbihi kęfyę ohę n, cai ęci nͻcḛ ᴐma iyḛ bei k’ͻdah.</para>
+      <para>Odudu acɛ duu iciko bei kipu kinu-agba aman bɛ okw’ɔcɛ dudu igbihi kɛfyɛ ohɛ n, cai ɛci nɔcɛ ᴐma iyɛ bei k’ɔdah.</para>
    </article>
    <article number="10">
       <title>OKA 10</title>
-      <para>Odudu acḛ cika j’ojinlę lębę k’aw okępͻ ipu k’ębͻ ͻkpakpa mḛml’ębͻ ni lojeikpei n oka tig ko kępͻ k’ͻcę duu kl’ęcę pee, Ohigb’ͻdah ni yabͻ kunu nᴐ je hai tig k’ępͻ gͻda bᴐbi ḛgḛ dudu ni kwͻcę ępͻ kunu.</para>
+      <para>Odudu acɛ cika j’ojinlɛ lɛbɛ k’aw okɛpɔ ipu k’ɛbɔ ɔkpakpa mɛml’ɛbɔ ni lojeikpei n oka tig ko kɛpɔ k’ɔcɛ duu kl’ɛcɛ pee, Ohigb’ɔdah ni yabɔ kunu nᴐ je hai tig k’ɛpɔ gɔda bᴐbi ɛgɛ dudu ni kwɔcɛ ɛpɔ kunu.</para>
    </article>
    <article number="11">
       <title>OKA 11</title>
       <orderedlist>
          <listitem>
-            <para>Ɔcę duu ni kwępͻ hibi gͻda olukpafyu ikpo ḛgḛ duu nę, ilęp’mbi ęci naw’ͻkępͻ lępͻ kunu ka ei pee ip’ͻkpakpa mḛml’ḛgḛ duu nͻdah lę, nacḛ okḛpᴐ kunu kw’ḛga je lᴐ kᴐ-nu ka ip’ᴐda nᴐcḛ ᴐma ya.</para>
+            <para>Ɔcɛ duu ni kwɛpɔ hibi gɔda olukpafyu ikpo ɛgɛ duu nɛ, ilɛp’mbi ɛci naw’ɔkɛpɔ lɛpɔ kunu ka ei pee ip’ɔkpakpa mɛml’ɛgɛ duu nɔdah lɛ, nacɛ okɛpᴐ kunu kw’ɛga je lᴐ kᴐ-nu ka ip’ᴐda nᴐcɛ ᴐma ya.</para>
          </listitem>
          <listitem>
-            <para>Ɔcę duu I ciko lęp’ḛmbi ohigb’ͻda duu nͻdah kęi gaję nͻ la aa ma ma ta tͻ n liko nͻcę ͻma yͻda lͻ. aman bḛ kofy’ ęfye fyowu kine nͻcę kpo aa janu fy’ḛgḛ abᴐ nͻdah myla ta go fajanu liko nͻcę kpine aa.</para>
+            <para>Ɔcɛ duu I ciko lɛp’ɛmbi ohigb’ɔda duu nɔdah kɛi gajɛ nɔ la aa ma ma ta tɔ n liko nɔcɛ ɔma yɔda lɔ. aman bɛ kofy’ ɛfye fyowu kine nɔcɛ kpo aa janu fy’ɛgɛ abᴐ nɔdah myla ta go fajanu liko nɔcɛ kpine aa.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="12">
       <title>OKA 12</title>
-      <para>Odudu acę cika w’ohyl’ęta jacę ͻmpa kuwa ki labͻ lͻda ot’otu nᴐcḛ iya n, aman bḛ k’ip’ͻnu kuwa n, ͻl’uwa n, aman bḛ k’okpo dͻcę ikwęi gojima-nu mḛml’ojima n. Ɔdah cika gbęi ͻcę duu kͻcę ͻha kͻ ma ko labͻ ip’ͻda ototu gͻc’ͻmpa-nu ḛgḛ duu.</para>
+      <para>Odudu acɛ cika w’ohyl’ɛta jacɛ ɔmpa kuwa ki labɔ lɔda ot’otu nᴐcɛ iya n, aman bɛ k’ip’ɔnu kuwa n, ɔl’uwa n, aman bɛ k’okpo dɔcɛ ikwɛi gojima-nu mɛml’ojima n. Ɔdah cika gbɛi ɔcɛ duu kɔcɛ ɔha kɔ ma ko labɔ ip’ɔda ototu gɔc’ɔmpa-nu ɛgɛ duu.</para>
    </article>
    <article number="13">
       <title>OKA 13</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah kabͻ kei nͻ ki yau gębę duu nya ni y’ͻtu-nu, nͻ ke la ęgę duu ni h’ͻtu ip’ęi aję nͻ la ᴐma.</para>
+            <para>Odudu acɛ lɔdah kabɔ kei nɔ ki yau gɛbɛ duu nya ni y’ɔtu-nu, nɔ ke la ɛgɛ duu ni h’ɔtu ip’ɛi ajɛ nɔ la ᴐma.</para>
          </listitem>
          <listitem>
-            <para>Odudu acḛ lͻdah ko nyę ђmęi gaję duu nͻ la gḛi ajḛ ᴐmpa, gͻ cokwu węi gaję ni m’ͻ ta, ḛgͻ ma nᴐ lͻdah ko chigbihu wa iko duu ni yᴐtu-nu gę.</para>
+            <para>Odudu acɛ lɔdah ko nyɛ ŋmɛi gajɛ duu nɔ la gɛi ajɛ ᴐmpa, gɔ cokwu wɛi gajɛ ni m’ɔ ta, ɛgɔ ma nᴐ lɔdah ko chigbihu wa iko duu ni yᴐtu-nu gɛ.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -80,7 +80,7 @@
       <title>OKA14</title>
       <orderedlist>
          <listitem>
-            <para>Ɔcę duu lͻdah go dͻka ti go mabahi lęi gaję ͻha, ipu gowe oma n ti gokpodͻcę n.</para>
+            <para>Ɔcɛ duu lɔdah go dɔka ti go mabahi lɛi gajɛ ɔha, ipu gowe oma n ti gokpodɔcɛ n.</para>
          </listitem>
          <listitem>
             <para>[missing]</para>
@@ -91,10 +91,10 @@
       <title>OKA 15</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah ko wͻi kaję.</para>
+            <para>Odudu acɛ lɔdah ko wɔi kajɛ.</para>
          </listitem>
          <listitem>
-            <para>Ɔcę duu cika gw’ͻwę kopyͻi kaję tͻcę ͻmpa kunu n, aman bḛ ko gw’ͻwę t’opyͻdah kͻi kaję kunu abͻ ђmęi gaję eye gͻmpa n.</para>
+            <para>Ɔcɛ duu cika gw’ɔwɛ kopyɔi kajɛ tɔcɛ ɔmpa kunu n, aman bɛ ko gw’ɔwɛ t’opyɔdah kɔi kajɛ kunu abɔ ŋmɛi gajɛ eye gɔmpa n.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -102,13 +102,13 @@
       <title>OKA 16</title>
       <orderedlist>
          <listitem>
-            <para>Acęnyilͻ mḛml’Achęnya ni jejinkpa mę, ędͻ kacę, ęi kaję, aman bḛ k’ędͻ gowoico nigblḛgba icika gwͻwę to lei wa ͻba mḛml’ͻnya n aman bḛ ko h’ipͻnu kuwa n. Iciko lͻdah jojinlę ipu okpei-wa bͻha mḛml’okͻ hͻha ta kuwa.</para>
+            <para>Acɛnyilɔ mɛml’Achɛnya ni jejinkpa mɛ, ɛdɔ kacɛ, ɛi kajɛ, aman bɛ k’ɛdɔ gowoico nigblɛgba icika gwɔwɛ to lei wa ɔba mɛml’ɔnya n aman bɛ ko h’ipɔnu kuwa n. Iciko lɔdah jojinlɛ ipu okpei-wa bɔha mɛml’okɔ hɔha ta kuwa.</para>
          </listitem>
          <listitem>
-            <para>Ɔba mḛml’Ɔnya olę cika wͻda nͻcę duu ibei gipu gunu ipu gotila n cai ipu ko mͻtu gei wa cici ti go lekwu kei wa.</para>
+            <para>Ɔba mɛml’Ɔnya olɛ cika wɔda nɔcɛ duu ibei gipu gunu ipu gotila n cai ipu ko mɔtu gei wa cici ti go lekwu kei wa.</para>
          </listitem>
          <listitem>
-            <para>Ipͻnu kᴐcę w’okwaję go hę igwu igwu gacę ma. Hibi ḛgᴐ ma ͻwᴐda ni cḛlḛgba kęi kaję odudu kᴐ kwula mḛml’ipͻnu.</para>
+            <para>Ipɔnu kᴐcɛ w’okwajɛ go hɛ igwu igwu gacɛ ma. Hibi ɛgᴐ ma ɔwᴐda ni cɛlɛgba kɛi kajɛ odudu kᴐ kwula mɛml’ipɔnu.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -116,29 +116,29 @@
       <title>OKA 17</title>
       <orderedlist>
          <listitem>
-            <para>Ɔcę duu nę lͻdah abͻ kei nu lͻdah ko labenu gei-nu amaa bę nͻ ke lᴐfyu ba tͻha yͻda kagbenu-nu mḛml’ͻcę ͻmpa.</para>
+            <para>Ɔcɛ duu nɛ lɔdah abɔ kei nu lɔdah ko labenu gei-nu amaa bɛ nɔ ke lᴐfyu ba tɔha yɔda kagbenu-nu mɛml’ɔcɛ ɔmpa.</para>
          </listitem>
          <listitem>
-            <para>Okwͻcę baję ębę ko lͻda kagbenu olḛ nya, kᴐ yͻ n.</para>
+            <para>Okwɔcɛ bajɛ ɛbɛ ko lɔda kagbenu olɛ nya, kᴐ yɔ n.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="18">
       <title>OKA 18</title>
-      <para>Odudu acḛ lͻdah ko lohili kͻda ḛgḛ ni h’ͻtu, aman bḛ k’Ocaikęla jͻcę ni la lipu kͻtu kͻcę, ti kędͻ kOwiocco nͻ igbęgba aa; ipu kͻdah nͻcę lę nya, ͻcę lͻfyu nyę ђmipu gęgba nͻ yᴐ gb’oco eye gipu g’ḛgḛ duu nͻcḛ ma, nᴐ ke h’ͻtu, mḛml’ojowoico ogbęgba kunu kl’ḛcḛ pee ęgę duu nę.</para>
+      <para>Odudu acɛ lɔdah ko lohili kɔda ɛgɛ ni h’ɔtu, aman bɛ k’Ocaikɛla jɔcɛ ni la lipu kɔtu kɔcɛ, ti kɛdɔ kOwiocco nɔ igbɛgba aa; ipu kɔdah nɔcɛ lɛ nya, ɔcɛ lɔfyu nyɛ ŋmipu gɛgba nɔ yᴐ gb’oco eye gipu g’ɛgɛ duu nɔcɛ ma, nᴐ ke h’ɔtu, mɛml’ojowoico ogbɛgba kunu kl’ɛcɛ pee ɛgɛ duu nɛ.</para>
    </article>
    <article number="19">
       <title>OKA 19</title>
-      <para>Ɔcę duu lͻdah gͻmͻwę gͻda abͻ ni yͻtu gunu ti go jͻwę gęla ka abͻ ni yͻtu gunu kpakpa; ͻmęwę gęla abͻ ni h’ͻcę ͻtu, gͻcę ͻha gͻlabͻ lͻ n kwęę ja gei nu bͻ n, ti go j’ͻwę gęla lͻ ka tęcę pee jacę lipu ginu ębę okęla tęcę abͻ duu nͻcę lͻ cokwu lę.</para>
+      <para>Ɔcɛ duu lɔdah gɔmɔwɛ gɔda abɔ ni yɔtu gunu ti go jɔwɛ gɛla ka abɔ ni yɔtu gunu kpakpa; ɔmɛwɛ gɛla abɔ ni h’ɔcɛ ɔtu, gɔcɛ ɔha gɔlabɔ lɔ n kwɛɛ ja gei nu bɔ n, ti go j’ɔwɛ gɛla lɔ ka tɛcɛ pee jacɛ lipu ginu ɛbɛ okɛla tɛcɛ abɔ duu nɔcɛ lɔ cokwu lɛ.</para>
    </article>
    <article number="20">
       <title>OKA 20</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah gojlei mḛml’acę duu ipu kͻgbͻtu tig ko by’atͻha mḛmyl’acę ͻha duu.</para>
+            <para>Odudu acɛ lɔdah gojlei mɛml’acɛ duu ipu kɔgbɔtu tig ko by’atɔha mɛmyl’acɛ ɔha duu.</para>
          </listitem>
          <listitem>
-            <para>Ɔcę duu gͻ yͻcę ͻmpa otila k’ͻwę lᴐwa ᴐwa aman bḛ k’opyatͻha kacę duu nę n.</para>
+            <para>Ɔcɛ duu gɔ yɔcɛ ɔmpa otila k’ɔwɛ lᴐwa ᴐwa aman bɛ k’opyatɔha kacɛ duu nɛ n.</para>
          </listitem>
      </orderedlist>
    </article>
@@ -146,49 +146,49 @@
       <title>OKA 21</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah ko labͻ lipu gigͻmęnti kęi gaję-nu, ͻlͻfyu nyęga kͻkwęi kacę kunu aman bḛ k’ofͻcę ni kwęi gunu lipu gigͻmęnti.</para>
+            <para>Odudu acɛ lɔdah ko labɔ lipu gigɔmɛnti kɛi gajɛ-nu, ɔlɔfyu nyɛga kɔkwɛi kacɛ kunu aman bɛ k’ofɔcɛ ni kwɛi gunu lipu gigɔmɛnti.</para>
          </listitem>
          <listitem>
-            <para>Odudu acę lͻdah jojinlę ko yękwu mḛml’ͻda geniye duu.</para>
+            <para>Odudu acɛ lɔdah jojinlɛ ko yɛkwu mɛml’ɔda geniye duu.</para>
          </listitem>
          <listitem>
-            <para>Ɔda ni wokwaję kͻdah gigͻmęnti cika wͻda nęwa kacę iyᴐ dͻka; ḛnya ka itei pee fyę lipu kabͻ obͻkpa nicaka yͻ iko iko gunu, ohigb’ęwa gacę gͻ f’ͻcę ni kwęi kuwa lipu gigͻmęnti ipu kabͻ obͻkpa ni l’uji n.</para>
+            <para>Ɔda ni wokwajɛ kɔdah gigɔmɛnti cika wɔda nɛwa kacɛ iyᴐ dɔka; ɛnya ka itei pee fyɛ lipu kabɔ obɔkpa nicaka yɔ iko iko gunu, ohigb’ɛwa gacɛ gɔ f’ɔcɛ ni kwɛi kuwa lipu gigɔmɛnti ipu kabɔ obɔkpa ni l’uji n.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="22">
       <title>OKA 22</title>
-      <para>Odudu acę ni wᴐi kaję ḛgḛ nͻ la, lͻdah ko gbęi-wa ip’ola kuwa mḛml’ obębę kakanya nęi kaję ęi-aję ti k’igwu igwu kace cika ya ohigb’ͻcę ko je ͻkpͻci kͻdah kunu nͻ lę ipu koya ję gͻbu kͻcę mḛml’abͻ nͻcę yᴐ yoyei lę ni ki lͻcę py’ͻcḛ kejiji n, kęnębęcę kͻcę gͻ yᴐ ję tip’ejinkpa.</para>
+      <para>Odudu acɛ ni wᴐi kajɛ ɛgɛ nɔ la, lɔdah ko gbɛi-wa ip’ola kuwa mɛml’ obɛbɛ kakanya nɛi kajɛ ɛi-ajɛ ti k’igwu igwu kace cika ya ohigb’ɔcɛ ko je ɔkpɔci kɔdah kunu nɔ lɛ ipu koya jɛ gɔbu kɔcɛ mɛml’abɔ nɔcɛ yᴐ yoyei lɛ ni ki lɔcɛ py’ɔcɛ kejiji n, kɛnɛbɛcɛ kɔcɛ gɔ yᴐ jɛ tip’ejinkpa.</para>
    </article>
    <article number="23">
       <title>OKA 23</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah ko y’ukͻlͻ duu, aman bḛ oj’ędͻ kukͻlͻ ni h’ͻtu, nͻ iya ni ke gbiye nęę gila dę kͻ ya ti gͻdah ni gbͻcę holukͻlͻ no ta.</para>
+            <para>Odudu acɛ lɔdah ko y’ukɔlɔ duu, aman bɛ oj’ɛdɔ kukɔlɔ ni h’ɔtu, nɔ iya ni ke gbiye nɛɛ gila dɛ kɔ ya ti gɔdah ni gbɔcɛ holukɔlɔ no ta.</para>
          </listitem>
          <listitem>
-            <para>Odudu acḛ duu ni yukͻlͻ igwu eyekponu lͻdah ko my’ule ḛgḛ ekponu cai oyoyͻ gukͻlͻ guwa kᴐ yͻ gbͻbu dę nule kuwa y’oyͻ duu ma.</para>
+            <para>Odudu acɛ duu ni yukɔlɔ igwu eyekponu lɔdah ko my’ule ɛgɛ ekponu cai oyoyɔ gukɔlɔ guwa kᴐ yɔ gbɔbu dɛ nule kuwa y’oyɔ duu ma.</para>
          </listitem>
          <listitem>
-            <para>Odudu acḛ ni yukͻlͻ,lͻdah hibi kͻ lͻda ni lͻfyu bͻya mḛml’ipͻnu kunu cę janu aman bę k’ipͻnu kunu hai tei gabͻ nipͻnu gͻcę ciko lę ipu gojima.</para>
+            <para>Odudu acɛ ni yukɔlɔ,lɔdah hibi kɔ lɔda ni lɔfyu bɔya mɛml’ipɔnu kunu cɛ janu aman bɛ k’ipɔnu kunu hai tei gabɔ nipɔnu gɔcɛ ciko lɛ ipu gojima.</para>
          </listitem>
          <listitem>
-            <para>Odudu acę lͻdah ko h’utu kͻyi ota aman ko wę lipu kopyatͻha ga w’otͻyi ohigb’ile nͻ gi lę aa.</para>
+            <para>Odudu acɛ lɔdah ko h’utu kɔyi ota aman ko wɛ lipu kopyatɔha ga w’otɔyi ohigb’ile nɔ gi lɛ aa.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="24">
       <title>OKA 24</title>
-      <para>Odudu acḛ lͻdah ko lͻmlęnyͻ ip’ukͻlͻ duu nͻ iya, aman bḛ k’ukͻlͻ duu nͻcę iya cika liko gunu aman bḛ k’auwa nͻcę iyukͻlͻ duu nya ciko lęji. Iko Iko omęnyͻ yͻ ipu gukͻlͻ duu mḛml’ule oca.</para>
+      <para>Odudu acɛ lɔdah ko lɔmlɛnyɔ ip’ukɔlɔ duu nɔ iya, aman bɛ k’ukɔlɔ duu nɔcɛ iya cika liko gunu aman bɛ k’auwa nɔcɛ iyukɔlɔ duu nya ciko lɛji. Iko Iko omɛnyɔ yɔ ipu gukɔlɔ duu mɛml’ule oca.</para>
    </article>
    <article number="25">
       <title>OKA 25</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acḛ lͻdah ko l’oyei ͻlam ni cika jͻ lafyiya lͻcę mḛml’ogbęhi gęnębęcę kͻcę ti k’ipͻnu kunu, ḛg’ͻda lę b’odule, ͻda oliye, ęgę ojęyi nyletu aman bę k’ͻlę ti kojikpei tͻkp’iye kᴐcḛ, okplici kͻcę ti gͻda ohoi ni cęgba.</para>
+            <para>Odudu acɛ lɔdah ko l’oyei ɔlam ni cika jɔ lafyiya lɔcɛ mɛml’ogbɛhi gɛnɛbɛcɛ kɔcɛ ti k’ipɔnu kunu, ɛg’ɔda lɛ b’odule, ɔda oliye, ɛgɛ ojɛyi nyletu aman bɛ k’ɔlɛ ti kojikpei tɔkp’iye kᴐcɛ, okplici kɔcɛ ti gɔda ohoi ni cɛgba.</para>
          </listitem>
          <listitem>
-            <para>Ęnę omͻi tig ͻi wei gͻcę duu go jei tuwa hͻhͻi ti go bi yuwa ͻtabͻ. Ɔi duu nęę kwͻha ni ma lipu golekwu gOco aman kwęę olekw gOco no cika lojei tuwa ti go kwula huwa jojinlę.</para>
+            <para>Ęnɛ omɔi tig ɔi wei gɔcɛ duu go jei tuwa hɔhɔi ti go bi yuwa ɔtabɔ. Ɔi duu nɛɛ kwɔha ni ma lipu golekwu gOco aman kwɛɛ olekw gOco no cika lojei tuwa ti go kwula huwa jojinlɛ.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -196,13 +196,13 @@
       <title>OKA 26</title>
       <orderedlist>
          <listitem>
-            <para>Ɔcę duu lͻdah go ginͻkpa ga jͻkpa. Ɔkpa oje cika wa gęhi, ͻwͻda nͻ nyę fyę gba okwaję gͻkpa oje cika wagęhi gͻ ca wotila gͻcę duu gͻ lokwaję gͻkpa oje ya ipu ginͻkpa. Ɔkpa oje gͻbu cika wota jͻcę duu ni dͻka go je gͻbu tei gabͻ nowu gunu jͻ.</para>
+            <para>Ɔcɛ duu lɔdah go ginɔkpa ga jɔkpa. Ɔkpa oje cika wa gɛhi, ɔwɔda nɔ nyɛ fyɛ gba okwajɛ gɔkpa oje cika wagɛhi gɔ ca wotila gɔcɛ duu gɔ lokwajɛ gɔkpa oje ya ipu ginɔkpa. Ɔkpa oje gɔbu cika wota jɔcɛ duu ni dɔka go je gɔbu tei gabɔ nowu gunu jɔ.</para>
          </listitem>
          <listitem>
-            <para>Ɔkpa oje ciko wͻda ni cę jͻce ję gͻbu ipu ko jlakwęi gęnębęcę ͻcę mḛml’o jukpafyu jͻdah nͻcę lę abͻ kei-nu nya ti go labͻ lei-ђ nͻcę lę aa. Ɔkpa oje ca I cę lo jęi kͻda ję gͻbu, oђmabͻ hęla ta mḛml’oyęma ti acę ͻmpa, aman bḛ k’ędͻ gacę ogbowoico ͻmpa, ͻ ke i cę jukͻlͻ g’United Nations ohigb’ͻgbͻtu ko yͻ ipu gęcę nya ję gͻbu.</para>
+            <para>Ɔkpa oje ciko wɔda ni cɛ jɔce jɛ gɔbu ipu ko jlakwɛi gɛnɛbɛcɛ ɔcɛ mɛml’o jukpafyu jɔdah nɔcɛ lɛ abɔ kei-nu nya ti go labɔ lei-ŋ nɔcɛ lɛ aa. Ɔkpa oje ca I cɛ lo jɛi kɔda jɛ gɔbu, oŋmabɔ hɛla ta mɛml’oyɛma ti acɛ ɔmpa, aman bɛ k’ɛdɔ gacɛ ogbowoico ɔmpa, ɔ ke i cɛ jukɔlɔ g’United Nations ohigb’ɔgbɔtu ko yɔ ipu gɛcɛ nya jɛ gɔbu.</para>
          </listitem>
          <listitem>
-            <para>Aw’ada lͻdah gi jędͻ gͻkpa oje ni wei kai-wa ni ke lͻhii ko je luwa.</para>
+            <para>Aw’ada lɔdah gi jɛdɔ gɔkpa oje ni wei kai-wa ni ke lɔhii ko je luwa.</para>
          </listitem>
       </orderedlist>
    </article>
@@ -210,33 +210,33 @@
       <title>OKA 27</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acę lͻdah ko lab’ipu ͻda atͻ gęi kaję duu nͻ la, ͻwͻda nͻ h’ͻtu, gͻdah lile gukͻlͻ gabͻ duu nacę gaję lͻ  byi hai ya.</para>
+            <para>Odudu acɛ lɔdah ko lab’ipu ɔda atɔ gɛi kajɛ duu nɔ la, ɔwɔda nɔ h’ɔtu, gɔdah lile gukɔlɔ gabɔ duu nacɛ gajɛ lɔ  byi hai ya.</para>
          </listitem>
          <listitem>
-            <para>Odudu acḛ lͻdah ko lei kw’aję aman bę ipu gukᴐl’abͻ duu, kw’ije nͻcę wo, kw’ͻkpa nͻcę ta, ͻcę ni w’ondu-nu aa lͻdah higbḛi k’ohili ni yipu kunu tig ͻda ni bi yekwu.</para>
+            <para>Odudu acɛ lɔdah ko lei kw’ajɛ aman bɛ ipu gukᴐl’abɔ duu, kw’ije nɔcɛ wo, kw’ɔkpa nɔcɛ ta, ɔcɛ ni w’ondu-nu aa lɔdah higbɛi k’ohili ni yipu kunu tig ɔda ni bi yekwu.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="28">
       <title>OKA 28</title>
-      <para>Ei oṅla yͻ jͻcę duu, ipu gęgḛ nya nęla kͻdah yi yabͻ kͻcę ti go labͻ lei-ђ kͻcę ni yᴐ ka lipu kͻkpa nya ilęi kila ip’acę kḛcḛ nya aa.</para>
+      <para>Ei oŋla yɔ jɔcɛ duu, ipu gɛgɛ nya nɛla kɔdah yi yabɔ kɔcɛ ti go labɔ lei-ŋ kɔcɛ ni yᴐ ka lipu kɔkpa nya ilɛi kila ip’acɛ kɛcɛ nya aa.</para>
    </article>
    <article number="29">
       <title>OKA 29</title>
       <orderedlist>
          <listitem>
-            <para>Odudu acę ciko lukͻlͻ eye aman bḛ fy’oye nͻ bi abᴐ yᴐ ipu’ͻlę nͻ la, hibi ipu goya lḛa, dę no labͻ lei-ђ kͻcę mḛml’ojḛ tijijinkpa gęnębęcę ͻcę ilęi gila ma. </para>
+            <para>Odudu acɛ ciko lukɔlɔ eye aman bɛ fy’oye nɔ bi abᴐ yᴐ ipu’ɔlɛ nɔ la, hibi ipu goya lɛa, dɛ no labɔ lei-ŋ kɔcɛ mɛml’ojɛ tijijinkpa gɛnɛbɛcɛ ɔcɛ ilɛi gila ma. </para>
          </listitem>
          <listitem>
-            <para>Ipu kͻdah kabͻ-ͻcę duu nę nͻ bi yᴐ yͻda duu aa, gͻ bi ya tei kabͻ nͻdah kęi kaję myla ta ko ya, ohigb’ͻgbͻtu mḛml’ojęgͻbu gͻ yęi gaję duu ti go ca cę j’olabͻ lei-ђ gͻcę ti gͻdah gabͻ gͻcę lojima.</para>
+            <para>Ipu kɔdah kabɔ-ɔcɛ duu nɛ nɔ bi yᴐ yɔda duu aa, gɔ bi ya tei kabɔ nɔdah kɛi kajɛ myla ta ko ya, ohigb’ɔgbɔtu mɛml’ojɛgɔbu gɔ yɛi gajɛ duu ti go ca cɛ j’olabɔ lei-ŋ gɔcɛ ti gɔdah gabɔ gɔcɛ lojima.</para>
          </listitem>
          <listitem>
-            <para>Ipu gͻdah gabͻ gͻcę ni ka nę ti g’olabͻ lei-ђ gͻcę ni ka nę, ͻcę duu gͻ byͻ yͻkͻlͻ ni gi by’ͻgbͻtu waję n no.</para>
+            <para>Ipu gɔdah gabɔ gɔcɛ ni ka nɛ ti g’olabɔ lei-ŋ gɔcɛ ni ka nɛ, ɔcɛ duu gɔ byɔ yɔkɔlɔ ni gi by’ɔgbɔtu wajɛ n no.</para>
          </listitem>
       </orderedlist>
    </article>
    <article number="30">
       <title>OKA 30</title>
-      <para>Ɔlͻdah duu ipu gͻdah gabͻni je ka lipu gͻkpa cę jͻcę duu n kwęę igwu igwu gacę duu n go bei gipu gͻda oya duu ni by’ͻda obya waję, aman gͻ byͻda duu n ikwęi gͻdah gabͻ gei nu n.</para>
+      <para>Ɔlɔdah duu ipu gɔdah gabɔni je ka lipu gɔkpa cɛ jɔcɛ duu n kwɛɛ igwu igwu gacɛ duu n go bei gipu gɔda oya duu ni by’ɔda obya wajɛ, aman gɔ byɔda duu n ikwɛi gɔdah gabɔ gei nu n.</para>
    </article>
 </udhr>

--- a/data/udhr/udhr_idu.xml
+++ b/data/udhr/udhr_idu.xml
@@ -3,7 +3,7 @@
 <!--© The Office of the High Commisioner for Human Rights-->
 
 <udhr iso639-3="idu" xml:lang="idu" key="idu" n="Idoma"  dir="ltr" iso15924="Latn" xmlns="http://www.unicode.org/udhr">
-   <title>OJE KA K’ĘLA KƆDAH NƆCĘ LĘ AA</title>
+   <title>OJE KA K’ƐLA KƆDAH NƆCƐ LƐ AA</title>
    <preamble>
       <title>Okwajɛ kɛla.</title>
       <para>Higbɛgɔ ma, oje ɔda ni w’ ɔkpɔci mɛml oj’ojinlɛ kɔdah nɔcɛ lɛ abɔ keinu lipu kipɔnu unu w’okwajɛ ko labɔ lei nu mɛml’ɛpɔ ɔkpakpa aa, tik ɔgbɔtu lipu kɛcɛ nya duu ma, higbɛgɔ ma, akwula n mɛml’ okpo dɔdah gɔcɛ iby’ɔda ni wei kunu n mɛmy’ olukpafyu ikpo wajɛ, ɛgɛ ni labɔ b’ocaiɛla jɔcɛ kipu k’ɔtu ɔcɛ bajɛ. Ohigbacɛ ni la lɛcɛ nya ki labahi kolabɔ lei wa ipu gɔkɔ okɛla-uwa, mɛml’okpohilice mɛml’oŋmatajɛ hukpo oya ta ti k’oyɔda tei kabɔ nɛw’acɛ idɔka ŋwule, higb’ɛgɔ ma ɔcɛgba nɛnɛhi kokwɔcɛ bajɛ mɛml’o yɔcɛ tɔha kɔma ko yɔ. Ɔ wei gunu kojɛgɔbu koyɔ ip’ɔinɛ oya mɛml’ɔmpa kunu. hibi kɔha nɛ, United Nations lohili ni tu ohibi k’ɔgbɔtu ko yɔ lɛi ajɛ duu je tajɛ fyɛ ikwɛi ɔdah nɔcɛ lɛ aa, hibi ko jɛgɔbu, mɛml’ojima tig oyei ɔlam k’ɔcɛ go yɔ ipu olabɔ lei nu. Igwu igwu kacɛ lɛlɛwa cɛ ko bɔha yukɔlɔ mɛml’United Nations ohigb ojɛgɔbu kɔdah ab’ɔcɛ ti k’aŋ leiŋ ma kɔcɛ ni wɔda agbanjala.</para>
@@ -11,7 +11,7 @@
    </preamble>
    <article number="1">
       <title>OKA 1</title>
-      <para>Ęgɛ ni modudu acɛ kɛcɛ nya bɛcɛ ɛhehi aa ,hibi ɛgɔ ma acɛ duu jonjilɛ ipu kocɛgba nɔcɛ cɛgba mɛml’ojonjilɛ ipu ɔdah ni yabɔ ɔcɛ nya. Odudu acɛ kwu ŋwule ml’ohili otu mɛml’ocai kɛla jɔcɛ ɔha ni yipu ɔtu ɔcɛ aa, higbɔ ma ɔcɛ higbo yɔda mɛml’ ɔmpa gunu lɛ bɔinɛ nu ma.</para>
+      <para>Ɛgɛ ni modudu acɛ kɛcɛ nya bɛcɛ ɛhehi aa ,hibi ɛgɔ ma acɛ duu jonjilɛ ipu kocɛgba nɔcɛ cɛgba mɛml’ojonjilɛ ipu ɔdah ni yabɔ ɔcɛ nya. Odudu acɛ kwu ŋwule ml’ohili otu mɛml’ocai kɛla jɔcɛ ɔha ni yipu ɔtu ɔcɛ aa, higbɔ ma ɔcɛ higbo yɔda mɛml’ ɔmpa gunu lɛ bɔinɛ nu ma.</para>
    </article>
    <article number="2">
       <title>OKA 2</title>
@@ -188,7 +188,7 @@
             <para>Odudu acɛ lɔdah ko l’oyei ɔlam ni cika jɔ lafyiya lɔcɛ mɛml’ogbɛhi gɛnɛbɛcɛ kɔcɛ ti k’ipɔnu kunu, ɛg’ɔda lɛ b’odule, ɔda oliye, ɛgɛ ojɛyi nyletu aman bɛ k’ɔlɛ ti kojikpei tɔkp’iye kᴐcɛ, okplici kɔcɛ ti gɔda ohoi ni cɛgba.</para>
          </listitem>
          <listitem>
-            <para>Ęnɛ omɔi tig ɔi wei gɔcɛ duu go jei tuwa hɔhɔi ti go bi yuwa ɔtabɔ. Ɔi duu nɛɛ kwɔha ni ma lipu golekwu gOco aman kwɛɛ olekw gOco no cika lojei tuwa ti go kwula huwa jojinlɛ.</para>
+            <para>Ɛnɛ omɔi tig ɔi wei gɔcɛ duu go jei tuwa hɔhɔi ti go bi yuwa ɔtabɔ. Ɔi duu nɛɛ kwɔha ni ma lipu golekwu gOco aman kwɛɛ olekw gOco no cika lojei tuwa ti go kwula huwa jojinlɛ.</para>
          </listitem>
       </orderedlist>
    </article>


### PR DESCRIPTION
Fixes #103.

This replaces U+037B ɔ with U+0254 ɔ, Ḙ with Ɛ, ę and ḛ with ɛ and ђ and ṅ with ŋ.

Abraham 1985 [1] indicates ɛ or ẹ and ɔ or ọ are used.

[1] R.C. Abraham, Idoma orthography, in Ayo Banjo, Orthographies of Nigerian Languages: Manual III, Lagos, National Language Center, 1985