### PR TITLE
hau_NG: replace ‘y by ’y

### DIFF
--- a/data/udhr/udhr_hau_NG.xml
+++ b/data/udhr/udhr_hau_NG.xml
@@ -8,31 +8,31 @@
   <preamble>
     <title>Gabatarwa</title>
 
-    <para>Ganin cewa ‘yanci da adalci da zaman lafiya ba za su girku a duniya ba, sai in an amince da cewa: dukkan ‘yan-adam suna da mutunci, kuma suna da hakkoki na kowa daidai da na kowa, waɗanda ba za a iya ƙwace musu ba,</para>
-    <para>Ganin cewa ba abin da ya sa aka aikata abubuwa irin na lokacin jahiliyya waɗanda ke tada hankalin duniya gaba-ɗaya, illa rashin sanin hakkokin ɗan-adam da rena su. Ganin kuma cewa an bayyana cewa: muhimmin gurin da ‘yan-adam suka sa gaba shi ne, bayan sun kuɓuta daga tsananin iko da wahala, kowa ya sami damar faɗin ra'ayinsa kuma ya sa rai ga abin da zuciyarsa ta saka masa,</para>
-    <para>Ganin cewa ya kamata a kafa hukumomi waɗanda za su kula da kiyayewa da hakkokin ‘yan-adam, ta hanyar girka dokoki, domin kada tsananin iko da danniya su yi yawa har su kai mutane ga yin kara ko yin tawaye,</para>
+    <para>Ganin cewa ’yanci da adalci da zaman lafiya ba za su girku a duniya ba, sai in an amince da cewa: dukkan ’yan-adam suna da mutunci, kuma suna da hakkoki na kowa daidai da na kowa, waɗanda ba za a iya ƙwace musu ba,</para>
+    <para>Ganin cewa ba abin da ya sa aka aikata abubuwa irin na lokacin jahiliyya waɗanda ke tada hankalin duniya gaba-ɗaya, illa rashin sanin hakkokin ɗan-adam da rena su. Ganin kuma cewa an bayyana cewa: muhimmin gurin da ’yan-adam suka sa gaba shi ne, bayan sun kuɓuta daga tsananin iko da wahala, kowa ya sami damar faɗin ra'ayinsa kuma ya sa rai ga abin da zuciyarsa ta saka masa,</para>
+    <para>Ganin cewa ya kamata a kafa hukumomi waɗanda za su kula da kiyayewa da hakkokin ’yan-adam, ta hanyar girka dokoki, domin kada tsananin iko da danniya su yi yawa har su kai mutane ga yin kara ko yin tawaye,</para>
     <para>Ganin cewa ya kamata a ƙarfafa aminci tsakanin ƙasashe,</para>
-    <para>Ganin cewa a cikin usular (takardar sharuɗa) al'ummu, ƙasashen duniya sun sake nuna amincewarsu da muhimman hakkokin ‘yan-adam, da mutuncinsu, da darajar da waɗannan halittu suke da ita kuma a kan daidai-wa-daida ga namiji da mace, suka kuma ɗauki alkawalin yin ƙoƙari domin su kyautata wa ‘yan-adam jin daɗin rayuwa a cikin suna ƙara walawa da ‘yancinsu,</para>
-    <para>Ganin cewa ƙasashen da Majalisar Ɗinkin Duniya ta ƙunsa sun ɗauki alkawalin cewa: tare da haɗin gwiwar Majalisar, za su tabbatar da abin da zai sa ko'ina a duniya a kiyaye da dukkan muhimman hakkokin ‘yan-adam da dukkan abubuwan da ‘yancinsu ya ƙunsa,</para>
-    <para>Ganin cewa muhimmin abin da zai sa a cika wannan alkawali shi ne, dukkan ƙasashen duniya su zamanto da huska ɗaya za su hangi waɗannan hakkokin ‘yan-adam da abubuwan da ‘yancinsu ya ƙunsa,</para>
+    <para>Ganin cewa a cikin usular (takardar sharuɗa) al'ummu, ƙasashen duniya sun sake nuna amincewarsu da muhimman hakkokin ’yan-adam, da mutuncinsu, da darajar da waɗannan halittu suke da ita kuma a kan daidai-wa-daida ga namiji da mace, suka kuma ɗauki alkawalin yin ƙoƙari domin su kyautata wa ’yan-adam jin daɗin rayuwa a cikin suna ƙara walawa da ’yancinsu,</para>
+    <para>Ganin cewa ƙasashen da Majalisar Ɗinkin Duniya ta ƙunsa sun ɗauki alkawalin cewa: tare da haɗin gwiwar Majalisar, za su tabbatar da abin da zai sa ko'ina a duniya a kiyaye da dukkan muhimman hakkokin ’yan-adam da dukkan abubuwan da ’yancinsu ya ƙunsa,</para>
+    <para>Ganin cewa muhimmin abin da zai sa a cika wannan alkawali shi ne, dukkan ƙasashen duniya su zamanto da huska ɗaya za su hangi waɗannan hakkokin ’yan-adam da abubuwan da ’yancinsu ya ƙunsa,</para>
     <para>Majalisar Ɗinkin Duniya, a zaman taronta na gaba-ɗaya ta faɗi cewa:</para>
-    <para>Abubuwan da wannan jawabi ya ƙunsa su zamanto gurin da dukkan al'ummu da ƙasashen duniya suka haɗu a kansa kuma suka yi ƙoƙarin cimma, domin kowane mutum da kowane sashen jama'a wanda yake da wannan jawabi a ka ko da wane lokaci, ya maida himma ta hanyar tsarin makarantu da tarbiyya domin a ƙarfafa kiyayewa da waɗannan hakkoki da dukkan abubuwan da ‘yancin ɗan-adam ya ƙunsa. Bayan haka a yi ƙoƙari ta hanyar ɗaukar matakai waɗanda za a rika ingantawa lokaci zuwa lokaci, kuma waɗanda za su shafi ƙasa ɗaya ko ƙasashe da yawa domin ko'ina a duniya jama'ar ƙasashen da Majalisar Ɗinkin Duniya ta ƙunsa da ta ƙasashen da ke ƙarƙashin mulkin waɗansu daga cikinsu ta karɓi wannan jawabi, ta kuma yi amfani da shi yadda ya kamata.</para>
+    <para>Abubuwan da wannan jawabi ya ƙunsa su zamanto gurin da dukkan al'ummu da ƙasashen duniya suka haɗu a kansa kuma suka yi ƙoƙarin cimma, domin kowane mutum da kowane sashen jama'a wanda yake da wannan jawabi a ka ko da wane lokaci, ya maida himma ta hanyar tsarin makarantu da tarbiyya domin a ƙarfafa kiyayewa da waɗannan hakkoki da dukkan abubuwan da ’yancin ɗan-adam ya ƙunsa. Bayan haka a yi ƙoƙari ta hanyar ɗaukar matakai waɗanda za a rika ingantawa lokaci zuwa lokaci, kuma waɗanda za su shafi ƙasa ɗaya ko ƙasashe da yawa domin ko'ina a duniya jama'ar ƙasashen da Majalisar Ɗinkin Duniya ta ƙunsa da ta ƙasashen da ke ƙarƙashin mulkin waɗansu daga cikinsu ta karɓi wannan jawabi, ta kuma yi amfani da shi yadda ya kamata.</para>
   </preamble>
 
   <article number="1">
     <title>Mataki na farko (1)</title>
-    <para>Su dai ‘yan-adam, ana haifuwarsu ne duka ‘yantattu, kuma kowannensu na da mutunci da hakkoki daidai da na kowa. Suna da hankali da tunani, saboda haka duk abin da za su aikata wa juna, ya kamata su yi shi a cikin ‘yan-uwanci.</para>
+    <para>Su dai ’yan-adam, ana haifuwarsu ne duka ’yantattu, kuma kowannensu na da mutunci da hakkoki daidai da na kowa. Suna da hankali da tunani, saboda haka duk abin da za su aikata wa juna, ya kamata su yi shi a cikin ’yan-uwanci.</para>
   </article>
 
   <article number="2">
     <title>Mataki na biyu (2)</title>
-    <para>Kowane mutum na da hujjar cin moriyar dukkan abubuwan da ‘yanci ya ƙunsa da dukkan hakkokin da aka bayyana a cikin wannan jawabi ba tare da bambanci ko kaɗan ba, ko na launin fata, ko na zama mace wala namiji, ko na harshe, ko na addini, ko na ra'ayin siyasa, ko kuma bambancin ra'ayin da ya shafi ƙasarsu, ko na zaman jama'a, ko na arziki, ko na haifuwa, ko na wani hali daban.</para>
+    <para>Kowane mutum na da hujjar cin moriyar dukkan abubuwan da ’yanci ya ƙunsa da dukkan hakkokin da aka bayyana a cikin wannan jawabi ba tare da bambanci ko kaɗan ba, ko na launin fata, ko na zama mace wala namiji, ko na harshe, ko na addini, ko na ra'ayin siyasa, ko kuma bambancin ra'ayin da ya shafi ƙasarsu, ko na zaman jama'a, ko na arziki, ko na haifuwa, ko na wani hali daban.</para>
     <para>Bayan haka, ba za a gwada wa mutum wani bambanci ba saboda matsayin ƙasarsu ko yankinsu a fannin siyasa ko na hukunce-hukuncen shari'a ko a huskar ƙasashen duniya, ko da kuwa ƙasar mai mulkin-kai ce, ko tana ƙarƙashin mulkin wata ƙasa, ko ba ta da cikakken mulkin-kai, ko da wani abin da ya rage mata mulki.</para>
   </article>
 
   <article number="3">
     <title>Mataki na uku (3)</title>
-    <para>Kowane mutum na da hakkin rayuwa, da zamantowa cikin ‘yanci da samun a kiyaye halittarsa.</para>
+    <para>Kowane mutum na da hakkin rayuwa, da zamantowa cikin ’yanci da samun a kiyaye halittarsa.</para>
   </article>
 
   <article number="4">
@@ -91,7 +91,7 @@
     <title>Mataki na goma sha uku (13)</title>
     <orderedlist>
       <listitem>
-	<para>Kowane mutum na da hakkin yin kai-da-kawowa cikin ‘yanci, ya ma zauna wurin da yake so a cikin wata ƙasa.</para>
+	<para>Kowane mutum na da hakkin yin kai-da-kawowa cikin ’yanci, ya ma zauna wurin da yake so a cikin wata ƙasa.</para>
       </listitem>
       <listitem>
 	<para>Kowane mutum na da hakkin ya fita daga kowace ƙasa, har da ƙasarsu kuma yana da hakkin komowa ƙasarsu.</para>
@@ -130,7 +130,7 @@
 	<para>Idan mace da namiji sun isa aure, suna da hakkin su auri juna su yi iyali, kuma za a yi auren ba tare da an rage wa waninsu darajarsa ta ɗan-adam ba saboda launin fatarsa ko don yana ɗan wata ƙasa ko kuma don addininsa. Kuma za su kasance da hakkoki na namiji daidai da na mace a game da wannan aure, a cikin zaman auren ko a lokacin rabuwa idan ta faru.</para>
       </listitem>
       <listitem>
-	<para>Ba za a ɗaura auren ba sai kowane daga cikin angwayen ya bada yardarsa cikin ‘yanci.</para>
+	<para>Ba za a ɗaura auren ba sai kowane daga cikin angwayen ya bada yardarsa cikin ’yanci.</para>
       </listitem>
       <listitem>
 	<para>Shi dai iyali shi ne muhimmin tushen jama'a, saboda haka ya kamata jama'a da hukuma su kiyaye shi.</para>
@@ -152,19 +152,19 @@
 
   <article number="18">
     <title>Mataki na goma sha takwas (18)</title>
-    <para>Kowane mutum na da hakkin ya sami ‘yancin yin tunani da na sanin ya kamata da na bin addini; saboda haka yana da ‘yancin sake addini ko ra'ayin da ya bada gaskiya gare shi, da kuma ‘yancin nuna addininsa ko ra'ayinsa, shi ɗaya ko a cikin taro kuma a fili ko a ɓoye ta hanyar koyarwa ko yin ibada, ko bauta wa abin da ya bada gaskiya gare shi da yin abubuwan da abin da yake bauta wa ɗin ya nuna masa.</para>
+    <para>Kowane mutum na da hakkin ya sami ’yancin yin tunani da na sanin ya kamata da na bin addini; saboda haka yana da ’yancin sake addini ko ra'ayin da ya bada gaskiya gare shi, da kuma ’yancin nuna addininsa ko ra'ayinsa, shi ɗaya ko a cikin taro kuma a fili ko a ɓoye ta hanyar koyarwa ko yin ibada, ko bauta wa abin da ya bada gaskiya gare shi da yin abubuwan da abin da yake bauta wa ɗin ya nuna masa.</para>
   </article>
 
   <article number="19">
     <title>Mataki na goma sha tara (19)</title>
-    <para>Kowane ɗan-adam na da hakkin ya sami ‘yancin kasancewa da ra'ayin kansa da ‘yancin faɗar ra'ayin nasa; saboda haka yana da hakkin ya sami ‘yancin kauda duk wani tsoro game da ra'ayoyinsa, da ‘yancin neman labaru da sababbin ra'ayoyi, ya same su kuma ya baza su duk inda yake so ba tare da sanin iyaka ba, kuma ta kowace hanya.</para>
+    <para>Kowane ɗan-adam na da hakkin ya sami ’yancin kasancewa da ra'ayin kansa da ’yancin faɗar ra'ayin nasa; saboda haka yana da hakkin ya sami ’yancin kauda duk wani tsoro game da ra'ayoyinsa, da ’yancin neman labaru da sababbin ra'ayoyi, ya same su kuma ya baza su duk inda yake so ba tare da sanin iyaka ba, kuma ta kowace hanya.</para>
   </article>
 
   <article number="20">
     <title>Mataki na ashirin (20)</title>
     <orderedlist>
       <listitem>
-	<para>Kowane mutum na da hakkin ya sami ‘yancin yin taro da kafa ƙungiyoyi tare da makamantansa muddin dai ƙungiyoyin na zaman lafiya ne.</para>
+	<para>Kowane mutum na da hakkin ya sami ’yancin yin taro da kafa ƙungiyoyi tare da makamantansa muddin dai ƙungiyoyin na zaman lafiya ne.</para>
       </listitem>
       <listitem>
 	<para>Ba wanda za a tilasta wa shiga wata ƙungiya.</para>
@@ -176,13 +176,13 @@
     <title>Mataki na ashirin da ɗaya (21)</title>
     <orderedlist>
       <listitem>
-	<para>Kowane mutum na da hakkin kasancewa a cikin ja-gorancin harkokin jama'a na ƙasarsu, ko shi da kansa ko ta hanyar aika wakilansa waɗanda ya zaba cikin ‘yanci.</para>
+	<para>Kowane mutum na da hakkin kasancewa a cikin ja-gorancin harkokin jama'a na ƙasarsu, ko shi da kansa ko ta hanyar aika wakilansa waɗanda ya zaba cikin ’yanci.</para>
       </listitem>
       <listitem>
 	<para>Kowane mutum na da hakki a cikin sharaɗin daidai-wa-daida ya sami halin a ɗaukaka shi ya kama ragamar tafiyar da waɗansu ayyukan ƙasarsu na kula da harkokin jama'a.</para>
       </listitem>
       <listitem>
-	<para>Yadda al'umma ke so ne mahakunta za su tafiyar da mulkin kasa; za a san buƙatar al'umma game da mulki ta hanyar gudanar da zabe kan gaskiya lokaci zuwa lokaci, inda dukkan ‘yan-ƙasa a zaman daidai-wa-daida muddin dai suna cikin sharaɗi, su sami damar zartar da zaben kuma cikin an yi jefa ƙuri'a a asirce ko ta wata hanya mai kama da haka, domin a tabbatar cewa kowa ya yi zabe cikin ‘yanci.</para>
+	<para>Yadda al'umma ke so ne mahakunta za su tafiyar da mulkin kasa; za a san buƙatar al'umma game da mulki ta hanyar gudanar da zabe kan gaskiya lokaci zuwa lokaci, inda dukkan ’yan-ƙasa a zaman daidai-wa-daida muddin dai suna cikin sharaɗi, su sami damar zartar da zaben kuma cikin an yi jefa ƙuri'a a asirce ko ta wata hanya mai kama da haka, domin a tabbatar cewa kowa ya yi zabe cikin ’yanci.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -196,10 +196,10 @@
     <title>Mataki na ashirin da uku (23)</title>
     <orderedlist>
       <listitem>
-	<para>Kowane mutum na da hakkin ya sami aiki, da ‘yancin ya zabi aikin da yake so dangance da ƙwarewarsa, ya kuma yi aikin kamar kowa a cikin sharaɗi gwargwado, kuma yana da hakkin a kiyaye shi da rashin aiki.</para>
+	<para>Kowane mutum na da hakkin ya sami aiki, da ’yancin ya zabi aikin da yake so dangance da ƙwarewarsa, ya kuma yi aikin kamar kowa a cikin sharaɗi gwargwado, kuma yana da hakkin a kiyaye shi da rashin aiki.</para>
       </listitem>
       <listitem>
-	<para>Dukkan ‘yan-adam, ba tare da wani bambanci ba, suna da hakkin su sami kimar albashi da‘ya idan aiki ɗaya suke yi.</para>
+	<para>Dukkan ’yan-adam, ba tare da wani bambanci ba, suna da hakkin su sami kimar albashi da’ya idan aiki ɗaya suke yi.</para>
       </listitem>
       <listitem>
 	<para>Duk wanda ke aiki na da hakkin ya sami albashi gwargwadon guminsa, wanda zai biya masa buƙatunsa na yau da kullum da shi da iyalinsa, kuma irin waɗanda suka kamaci ɗan-adam a cikin mutuncinsa. Bayan haka, idan akwai abubuwan da aka tsara don kyautata rayuwar jama'a, ya sami yin amfani da su.</para>
@@ -234,10 +234,10 @@
 	<para>Kowane mutum na da hakkin ya sami ilimi. Ya kamata ilimi ya zamanto ba na biya ba a ƙalla a cikin azuzuwan farko, wato tushen ilimi. Tilas ne ga kowa ya yi karatu a cikin azuzuwan farko. Ya kamata a baza ilimin husaha da na koyon sana'a a ko'ina. Duk wanda ƙwazonsa ya ba hali ya kamata a ba shi damar zuwa neman ilimin ƙoli ba tare da bambanci ba.</para>
       </listitem>
       <listitem>
-	<para>Abin nufi ga ilimi shi ne: ya sama wa ɗan-adam jin daɗin rayuwa da ƙarfafa kiyayewa da hakkokinsa da muhimman abubuwan da ‘yancinsa ya ƙunsa. Ya kamata ilimi ya kawo fahimtar juna da ragowa da aminci tsakanin ƙasashe da tsakanin ‘yan-adam, kome launin fatarsu da addinin da suke bi, ya kuma ƙarfafa ƙoƙarin da Majalisar Ɗinkin Duniya take yi domin a sami zaman lafiya da kwanciyar hankali a duniya.</para>
+	<para>Abin nufi ga ilimi shi ne: ya sama wa ɗan-adam jin daɗin rayuwa da ƙarfafa kiyayewa da hakkokinsa da muhimman abubuwan da ’yancinsa ya ƙunsa. Ya kamata ilimi ya kawo fahimtar juna da ragowa da aminci tsakanin ƙasashe da tsakanin ’yan-adam, kome launin fatarsu da addinin da suke bi, ya kuma ƙarfafa ƙoƙarin da Majalisar Ɗinkin Duniya take yi domin a sami zaman lafiya da kwanciyar hankali a duniya.</para>
       </listitem>
       <listitem>
-	<para>Game da neman ilimi, iyayen ne a gaba wajen hakkin faɗin irin tarbiyyar da za a yi wa ‘ya‘yansu.</para>
+	<para>Game da neman ilimi, iyayen ne a gaba wajen hakkin faɗin irin tarbiyyar da za a yi wa ’ya’yansu.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -246,7 +246,7 @@
     <title>Mataki na ashirin da bakwai (27)</title>
     <orderedlist>
       <listitem>
-	<para>Kowane mutum na da hakkin bada gwargwadon gudummuwarsa cikin ‘yanci ga dukkan al'amurran al'adu na da'irarsa da cin moriyar abubuwan da ake ƙagowa don daɗaɗa rai, da taimakawa ga ci-gaban kimiyya, haka kuma yana da hakkin ya yi amfani da hikimomin da da'irarsu ta tanada, da kyakkyawan sakamakon da aka samu daga kimiyya.</para>
+	<para>Kowane mutum na da hakkin bada gwargwadon gudummuwarsa cikin ’yanci ga dukkan al'amurran al'adu na da'irarsa da cin moriyar abubuwan da ake ƙagowa don daɗaɗa rai, da taimakawa ga ci-gaban kimiyya, haka kuma yana da hakkin ya yi amfani da hikimomin da da'irarsu ta tanada, da kyakkyawan sakamakon da aka samu daga kimiyya.</para>
       </listitem>
       <listitem>
 	<para>Kowa na da hakkin a yi masa kariya ta kowane hali, domin ya sami damar yin fara'a da cin amfanin abin da ya ƙirƙiro a fannin kimiyya ko na adabi ko na hikima.</para>
@@ -256,26 +256,26 @@
 
   <article number="28">
     <title>Mataki na ashirin da takwas (28)</title>
-    <para>Kowa na da hakkin ganin an sami kyakkyawan shiri a cikin zaman jama'a da tsakanin ƙasashen duniya domin hakkokin nan da dukkan abubuwan da ‘yanci ya ƙunsa waɗanda aka bayyana a cikin wannan jawabi su tabbata sosai.</para>
+    <para>Kowa na da hakkin ganin an sami kyakkyawan shiri a cikin zaman jama'a da tsakanin ƙasashen duniya domin hakkokin nan da dukkan abubuwan da ’yanci ya ƙunsa waɗanda aka bayyana a cikin wannan jawabi su tabbata sosai.</para>
   </article>
 
   <article number="29">
     <title>Mataki na ashirin da tara (29)</title>
     <orderedlist>
       <listitem>
-	<para>Ɗan-adam na da nauyin bauta wa da'irar da yake rayuwa a ciki a wuyansa, domin a nan kaɗai ne yake samun halin ƙarfafa darajarsa ta ɗan-adam cikin ‘yanci.</para>
+	<para>Ɗan-adam na da nauyin bauta wa da'irar da yake rayuwa a ciki a wuyansa, domin a nan kaɗai ne yake samun halin ƙarfafa darajarsa ta ɗan-adam cikin ’yanci.</para>
       </listitem>
       <listitem>
-	<para>Kowa zai yi amfani matuƙa da hakkokinsa da abubuwan da ‘yancinsa ya ƙunsa ba tare da wata iyaka ba, sai fa wadda doka ta kafa musamman domin a cikin zaman jama'a wadda ta san ma'anar dimukiraɗiyya, kowa ya san kuma ya kiyaye da hakkokin makamantansa da abubuwan da ‘yancinsu ya ƙunsa, kuma domin ɗa'a da kyakkyawan shirin jama'a da jin daɗin rayuwa ga kowa su tabbata kamar yadda ya kamata.</para>
+	<para>Kowa zai yi amfani matuƙa da hakkokinsa da abubuwan da ’yancinsa ya ƙunsa ba tare da wata iyaka ba, sai fa wadda doka ta kafa musamman domin a cikin zaman jama'a wadda ta san ma'anar dimukiraɗiyya, kowa ya san kuma ya kiyaye da hakkokin makamantansa da abubuwan da ’yancinsu ya ƙunsa, kuma domin ɗa'a da kyakkyawan shirin jama'a da jin daɗin rayuwa ga kowa su tabbata kamar yadda ya kamata.</para>
       </listitem>
       <listitem>
-	<para>Ta kowane hali ba za a iya yin amfani da waɗannan hakkoki da abubuwan da ‘yanci ya ƙunsa ba a cikin saba wa manufar Majalisar Ɗinkin Duniya da ka'idodinta.</para>
+	<para>Ta kowane hali ba za a iya yin amfani da waɗannan hakkoki da abubuwan da ’yanci ya ƙunsa ba a cikin saba wa manufar Majalisar Ɗinkin Duniya da ka'idodinta.</para>
       </listitem>
     </orderedlist>
   </article>
 
   <article number="30">
     <title>Mataki na talatin (30)</title>
-    <para>Ba wani mataki a cikin wannan jawabi, wanda wata ƙasa ko wata ƙungiya ko wani mutum zai yi amfani da shi, ya kwatanta cewa matakin ya ba shi ikon tafiyar da wata hidima, ko aikata wani abu da nufin rushe waɗannan hakkoki da abubuwan da ‘yanci ya ƙunsa, waɗanda aka bayyana a cikin wannan jawabi.</para>
+    <para>Ba wani mataki a cikin wannan jawabi, wanda wata ƙasa ko wata ƙungiya ko wani mutum zai yi amfani da shi, ya kwatanta cewa matakin ya ba shi ikon tafiyar da wata hidima, ko aikata wani abu da nufin rushe waɗannan hakkoki da abubuwan da ’yanci ya ƙunsa, waɗanda aka bayyana a cikin wannan jawabi.</para>
   </article>
 </udhr>


### PR DESCRIPTION
Word initial ‘y (with U+2018) is likely a word processor smart quote substitution. The spelling of the digraph is ’y (with U+2019) or 'y (with U+0027).