### PR TITLE
udhr_srr: replace ṕ by ƥ

### DIFF
--- a/data/udhr/udhr_srr.xml
+++ b/data/udhr/udhr_srr.xml
@@ -14,7 +14,7 @@
     <para>Ne fop a mbaruuna andit a ndamtin neen a jegta ngaa neen ke warna kiin a sogo jeg o njiriiñ</para>
     <para>MBOKATOOR MAAK NE</para>
     <para>Naa andintaa ee</para>
-    <para>Yeegnit neene adna fee ndeerna ni ke warna o kiinnen kaa wiine ƭop kam a caax ake kam pokatoor ke a mbarna and. A mbara o ndam yeegnit neene na yiif ake. Njeem kaa ɓaatuuna no saax ole na cangin ale na yar faye ndax ke yeegnit neene ɓissiɗna a waag o wuy kam a caax ake fa kam adna fee. A caax ake mbogna teen a mbaraan o andnitaa kam ṕasil dem.</para>
+    <para>Yeegnit neene adna fee ndeerna ni ke warna o kiinnen kaa wiine ƭop kam a caax ake kam pokatoor ke a mbarna and. A mbara o ndam yeegnit neene na yiif ake. Njeem kaa ɓaatuuna no saax ole na cangin ale na yar faye ndax ke yeegnit neene ɓissiɗna a waag o wuy kam a caax ake fa kam adna fee. A caax ake mbogna teen a mbaraan o andnitaa kam ƥasil dem.</para>
   </preamble>
   <article number="1">
     <title>Artiikal fa mberaand</title>
@@ -70,7 +70,7 @@
   </article>
   <article number="12">
     <title>Ar 12</title>
-    <para>O leng fiikilkaand no ñoow um, kam ṕasil um, kam mbindum mbaat kam ngentand um, mbala o layanan kaa jegeerna mbaat o jeema yakanin o waag um. Oxuu refna luwaa waraam o maakooy boo baa nandu neen a daawom.</para>
+    <para>O leng fiikilkaand no ñoow um, kam ƥasil um, kam mbindum mbaat kam ngentand um, mbala o layanan kaa jegeerna mbaat o jeema yakanin o waag um. Oxuu refna luwaa waraam o maakooy boo baa nandu neen a daawom.</para>
   </article>
   <article number="13">
     <title>Ar 13</title>
@@ -90,7 +90,7 @@
 	<para>Oxuu jegeerna o ɗaay me genoona, waagaa o ñaap saax laa waagoona o gen.</para>
       </listitem>
       <listitem>
-	<para>A soṕangaa a pi'a paaxeer o reefeel la ref kaa jegna waagatiro o muc no ke eteena o lay gaaga a pi'of a guutatira fa ƭaap ale mbokatoor ni keet ke njaɓ na.</para>
+	<para>A soƥangaa a pi'a paaxeer o reefeel la ref kaa jegna waagatiro o muc no ke eteena o lay gaaga a pi'of a guutatira fa ƭaap ale mbokatoor ni keet ke njaɓ na.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -115,7 +115,7 @@
 	<para>Ndonir ne waagee ɗeg to refee wee ndeernuna mbugun.</para>
       </listitem>
       <listitem>
-	<para>Ṕasil ten ref a paƴ ale xupna o njiriiñ no ñoow a wara o aarel na kenand axe fa kam saax le.</para>
+	<para>Ƥasil ten ref a paƴ ale xupna o njiriiñ no ñoow a wara o aarel na kenand axe fa kam saax le.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -177,7 +177,7 @@
 	<para>Fop mbodu teen jegee samtir callel nuu refna fi ndafidum.</para>
       </listitem>
       <listitem>
-	<para>Oxuu naa jallaa rawaa jeg muñoor kaa saqtoona ṕasil of boo te mbaag o yeeg o ñoow fel na keeñ den.</para>
+	<para>Oxuu naa jallaa rawaa jeg muñoor kaa saqtoona ƥasil of boo te mbaag o yeeg o ñoow fel na keeñ den.</para>
       </listitem>
       <listitem>
 	<para>Oxuu refna a waaga sos mbaat ta fog mbokaloor (sendikaa) ndi te waag o dax ke waruuna na pi'mbaat o jeg.</para>
@@ -192,7 +192,7 @@
     <title>Ar 25</title>
     <orderedlist>
       <listitem>
-	<para>Oxuu refna a wara jeg o ñoow olaa fadna fo ten, a topatoox o wod-o-ɗaal um fi ṕasil um: no ñaamel, na tikoorite, no genand, na baadin. A ware maakooy yaa ta ñakna callel um mbaat ta ɓ oowid mbaat taamala daawin.</para>
+	<para>Oxuu refna a wara jeg o ñoow olaa fadna fo ten, a topatoox o wod-o-ɗaal um fi ƥasil um: no ñaamel, na tikoorite, no genand, na baadin. A ware maakooy yaa ta ñakna callel um mbaat ta ɓ oowid mbaat taamala daawin.</para>
       </listitem>
       <listitem>
 	<para>Yaay ke fi ngoor ke a mbare maakooyeel a paax ngoor ke ndimeena kam a tolax ta we ndimaan deena kam a tolax den fop mbodu.</para>
@@ -209,7 +209,7 @@
 	<para>A cang ale wara jeg o njiriiñ o maak ni wiin we, a ɓaat a den boo to and a qoox den, ndax da mbaag o ñoow ni muñanir ni mbokatoor, ni nanir fa kaa jofondna a paam callel ke ni pokatoor ke xeet kembugna jam.</para>
       </listitem>
       <listitem>
-	<para>Baajur ke den mbaru njil a cang ale na ṕiy axe.</para>
+	<para>Baajur ke den mbaru njil a cang ale na ƥiy axe.</para>
       </listitem>
     </orderedlist>
   </article>


### PR DESCRIPTION
Sereer orthography uses ƥ, not ṕ. See Gouvernement du Sénégal, Décret no 2005-990 du 21 octobre 2005, or Ministry of Education material.

Replace ṕasil, ṕiy, a soṕangaa by ƥasil (family), ƥiy (children), a soƥangaa (if/when found).

Issue raised by @ebensorkin.