### PR TITLE
Windows-1252 to UTF-8 Encoding Bug for 3 files

### DIFF
--- a/data/udhr/udhr_kea.xml
+++ b/data/udhr/udhr_kea.xml
@@ -12,7 +12,7 @@
     <para>Nu ta considrâ qui, riconhecimento di dignidadi qui ta fazê parti di tudo membro di família humano e di sês drêto qui ê igual e qui nu ca podê squecê, nem ficâ separado di el, ê fundamento di liberdadi, di justiça e di paz di riba di ês mundo;</para>
     <para>Nu ta considrâ qui, disconhecimento e disprezo di drêto di tudo homi e di tudo mudjer lêbanu pa fazê cusas di rundade qui bem raboltâ concença di tudo Humanidadi. Nu sa ta spèrâ pa tchigâ um mundo undi tudo ser humano ta bem podê ser libri di podê papiâ e di crêditâ, liberto di terror e sim medo di pássâ fomi e di miséria. Tudo ês cusa bem ta ser porclamado cuma um inspiraçon muto importanti pâ nôs tudo: pâ homi e pâ mudjer.</para>
     <para>Nu ta considrâ qui ê essencial quel porteçon di drêto di homi e di mudjer dento di um rigimi di drêto, pamodi ês ca bem ta ser impurrado, num ricurso supremo, pâ bai pa ribolta contra tirania e opresson.</para>
-    <para>Nu ta considrâ quiê essencial si nu bem incorája quel disenvolvimemto di relaçon di amizadi di naçon co naçon.</para>
+    <para>Nu ta considrâ qui’ê essencial si nu bem incorája quel disenvolvimemto di relaçon di amizadi di naçon co naçon.</para>
     <para>Nu ta considrâ qui, naquel Carta, tudo pôbo di "Naçon Unido" ta porclama, ôto bez, qui eres tem fé na drêto fundamental di homi e di mudjer, na dignidadi e na valor de tudo péssoa humano, na igualdadi di drêto di homi e di mudjer, e ês diclara cuma ês sta resolvido pa bai favorecê purgresso social e eres sa ta bai ránjâ midjor condiçon di bida di pa dénto di muto más liberdadi.</para>
     <para>Nu ta considrâ qui tudo Estado membro dês grupo ta compromête pa pormovê na cooperaçon co Organizaçon di Naçon Unido, quel ruspêto universal e efectivo di drêto e di liberdadi fundamental.</para>
     <para>Nu ta considrâ qui um concepçon comum di êssi drêto e liberdadi ê di muto más importança pa podê dâ completo satisfaçon pa essi compromisso.</para>
@@ -25,7 +25,7 @@
   <article number="2">
     <title>Artigo 2º</title>
     <para>Tudo ser humano na ês mundo podi invocâ di drêto e di liberdadi qui sa ta ser porclamado nês Declaraçon li, sem distinçon algum di ôto, nomeadamenti, di raça, di cor, si el ê homi ô mudjer, si el tem ôto lingua, di religion ô di ôto crença, di opinion política, ô ôto li, di orija nacional ô social, di fortuna, di undi ê nacê ô di calquer ôto situaçon.</para>
-    <para>Dispôs disso tudo, ninguêm ca podê bem fazê ningum distinçon fundamentado na statuto político, na cusas di tribunal qui ta tchomádo "jurídico", ô internacional, di país ô di naçon undi bu nacê, nim qui esse naçon ô território di naturalidade dess péssoa mésmo qui essi país stâ indipendenti, ô stâ dibaxo di ordi di ôto, ô si el stâ libre ô dibaxo di algum limitaçõn di aôtoridadi, qui nu podê tchomal "di soberania".</para>
+    <para>Dispôs disso tudo, ninguêm ca podê bem fazê ningum distinçon fundamentado na statuto político, na cusas di tribunal qui ta tchomádo "jurídico", ô internacional, di país ô di naçon undi bu nacê, nim qui esse naçon ô território di naturalidade d’ess péssoa mésmo qui essi país stâ indipendenti, ô stâ dibaxo di ordi di ôto, ô si el stâ libre ô dibaxo di algum limitaçõn di aôtoridadi, qui nu podê tchoma’l "di soberania".</para>
   </article>
   <article number="3">
     <title>Artigo 3º</title>
@@ -49,7 +49,7 @@
   </article>
   <article number="8">
     <title>Artigo 8º</title>
-    <para>Tudo guenti tem drêto pa ricurso efectivo di quêxa na jurisdiçon nacional compitenti, di tudo cusa quê sabê qui tâ violâ nôs drêto qui tem más fundamento e qui é reconhecido na lei ô na Constituiçon.</para>
+    <para>Tudo guenti tem drêto pa ricurso efectivo di quêxa na jurisdiçon nacional compitenti, di tudo cusa qu’ê sabê qui tâ violâ nôs drêto qui tem más fundamento e qui é reconhecido na lei ô na Constituiçon.</para>
   </article>
   <article number="9">
     <title>Artigo 9º</title>
@@ -63,10 +63,10 @@
     <title>Artigo 11º</title>
     <orderedlist>
       <listitem>
-        <para>Tudo arguêm qui ta bem ser pontádo di um acçon di culpa, nu tem qui pensa quel stâ nôcenti tó qui si culpa bem ficâ sclarecido dénto di lei na andamento di um porcesso público undi tudo garantia necessário di difésa debê bem ser garantido pâ el.</para>
+        <para>Tudo arguêm qui ta bem ser pontádo di um acçon di culpa, nu tem qui pensa qu’el stâ nôcenti tó qui si culpa bem ficâ sclarecido dénto di lei na andamento di um porcesso público undi tudo garantia necessário di difésa debê bem ser garantido pâ el.</para>
       </listitem>
       <listitem>
-        <para>Ninguêm al pode ser condenado por acçon ô por omisson, si na occasion quel ta fazêba el, tudo es cusa ca era proibido dénto di lei di si téra ô di lei internacional. Di mesma manêra um djuiz ca podê sentenciâ castigo más pêsado di quêl que divia di ser na hora qui quel delito baba ta ser fêto.</para>
+        <para>Ninguêm al pode ser condenado por acçon ô por omisson, si na occasion qu’el ta fazêba el, tudo es cusa ca era proibido dénto di lei di si téra ô di lei internacional. Di mesma manêra um djuiz ca podê sentenciâ castigo más pêsado di quêl que divia di ser na hora qui quel delito baba ta ser fêto.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -81,7 +81,7 @@
         <para>Tudo arguêm tem drêto di àndâ pâ tudo lado, e di scôdjê si casa pa morâ dento di um Estado.</para>
       </listitem>
       <listitem>
-        <para>Tudo arguêm tem drêto di bandônâ calquer téra undi quê stâ, mesmo si ê undi ê nacê, e el tem drêto di bolta para si téra cando el crê.</para>
+        <para>Tudo arguêm tem drêto di bandônâ calquer téra undi qu’ê stâ, mesmo si ê undi ê nacê, e el tem drêto di bolta para si téra cando el crê.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -134,7 +134,7 @@
   </article>
   <article number="18">
     <title>Artigo 18º</title>
-    <para>Tudo péssoa tem drêto di tem liberdadi di pensamento, di concénça e di religion; ês drêto li ta implicâ liberdadi di mudâ di riligion ô di convicçon, asi cumâ quel liberdadi di maniféstâ sê religion ô sê convicçon, si el stâ só, el co el, ô cô ôtos, tanto na meio di público ô em particular, na quê ta fazê sempri, tudo dia, na sê religion e na quêl qui, na Portugal, ês ta tchomâ "ritos".</para>
+    <para>Tudo péssoa tem drêto di tem liberdadi di pensamento, di concénça e di religion; ês drêto li ta implicâ liberdadi di mudâ di riligion ô di convicçon, asi cumâ quel liberdadi di maniféstâ sê religion ô sê convicçon, si el stâ só, el co el, ô cô ôtos, tanto na meio di público ô em particular, na qu’ê ta fazê sempri, tudo dia, na sê religion e na quêl qui, na Portugal, ês ta tchomâ "ritos".</para>
   </article>
   <article number="19">
     <title>Artigo 19º</title>
@@ -194,7 +194,7 @@
     <title>Artigo 25º</title>
     <orderedlist>
       <listitem>
-        <para>Tudo péssoa tem drêto pa tem um condiçon di bida suficienti pa dal sigurança pâ êl e pâ família, na saúde e na larguéza, principalmenti na qui nu ta cumé, na nôs rôpa, pa tem undi el podê alôjâ arguêm, pa ser sistido pâ dôtor e tambê na serviço social necessáre, e ê tem drêto na sigurança social si el sta sim trabadjo, tambê na doénça, e inda naquel qui ê estropiado, qui câ tem marido, qui stâ na bedjiça, ô nôtos caso, di perdê manêra di tem meio di subsistença, por cusa qui podê ser indipendenti di sê vontade.</para>
+        <para>Tudo péssoa tem drêto pa tem um condiçon di bida suficienti pa da’l sigurança pâ êl e pâ família, na saúde e na larguéza, principalmenti na qui nu ta cumé, na nôs rôpa, pa tem undi el podê alôjâ arguêm, pa ser sistido pâ dôtor e tambê na serviço social necessáre, e ê tem drêto na sigurança social si el sta sim trabadjo, tambê na doénça, e inda naquel qui ê estropiado, qui câ tem marido, qui stâ na bedjiça, ô nôtos caso, di perdê manêra di tem meio di subsistença, por cusa qui podê ser indipendenti di sê vontade.</para>
       </listitem>
       <listitem>
         <para>Maternidade e infança tem drêto di tem djuda e di ser amparado co muto cudado. Tudo minino qui nacê dénto ô fora di casamento, ta goza di mésmo porteçon social.</para>
@@ -205,7 +205,7 @@
     <title>Artigo 26º</title>
     <orderedlist>
       <listitem>
-        <para>Tudo péssoa tem drêto pa tem educaçon. Educaçon débê di ser di graça, pelo menos quel qui ê parcêdo co quel di scóla elementar fundamental. Quel scola elementar ê obrigatóre. E nes scóla técnica e profissional dêbê di ser pa tudo criança sem distinçon; pa nu èntrâ num scóla superior, el dèbè stâ aberto pâ tudo guenti por igual e, segundo sês capacidadi e sês merecimento.</para>
+        <para>Tudo péssoa tem drêto pa tem educaçon. Educaçon débê di ser di graça, pelo menos quel qui ê parcêdo co quel di scóla elementar fundamental. Quel scola elementar ê obrigatóre. E n’es scóla técnica e profissional dêbê di ser pa tudo criança sem distinçon; pa nu èntrâ num scóla superior, el dèbè stâ aberto pâ tudo guenti por igual e, segundo sês capacidadi e sês merecimento.</para>
       </listitem>
       <listitem>
         <para>Educaçon debê pontâ pa espádjâ um completo expanson di personalidadi di tudo homi co tudo mudjer e pa reforçâ drêto e liberdadi fundamental di tudo homi co tudo mudjer e di liberdadi di más fundamento e ê debê djuda pa nu compreendê midjor quel tolerância e amizadi di naçon co naçon e di tudo grupo racial ou di riligion como tambê quel crescimento di actividadi di Naçon Unido pa conserbâ paz.</para>

--- a/data/udhr/udhr_kng_AO.xml
+++ b/data/udhr/udhr_kng_AO.xml
@@ -8,25 +8,25 @@
   <preamble>
     <title>THONONO</title>
     <para>Mu kibila ti luzabu lu nswa lu woso mutu, mkwa dikanda di bumutu, luidi mbandu kimpwanza, mbandu budedi ayi mbandu ndembama va ntoto;</para>
-    <para>Mu kibila ti bunzimbu ayi lulenzo lu miswa mi bumutu binnatanga ku phangulu mavanga manbayuwanga ku tsi-ntima bumutu, ayi mu kutala ti ngizulu yi nza yi bumutu bu kakuka mu matuba ayi mu ngwilukulu-zinzambi, ayi bu kakukeso mu themosono batu ayi mu buya-buphasi, yawu iyamukusu ti ngudi-lutia lu woso mutu;</para>
+    <para>Mu kibila ti bunzimbu ayi lulenzo lu miswa mi bumutu bin’natanga ku phangulu mavanga man’bayuwanga ku tsi-ntima bumutu, ayi mu kutala ti ngizulu yi nza yi bumutu bu kakuka mu matuba ayi mu ngwilukulu-zinzambi, ayi bu kakuk’eso mu themosono batu ayi mu buya-buphasi, yawu iyamukusu ti ngudi-lutia lu woso mutu;</para>
     <para>Mu kibila ti lukaku lu miswa mi bumutu mu ngolo yi butinu bu mikaka nkinza bene luidi, phasi mutu kabika kutisu kulanda nzila nganzi yi lubayusu lu mtinu ayi lubayusu lu lubyefomo;</para>
     <para>Mu kibila ti msamu-ngudi bene ndatusu ntwala yi bukundi ayi ngwizunu yi zitsi zioso;</para>
-    <para>Mu kibila ti mu Pfumu-Mkanda, zitsi zioso zi kinvuka ki Zitsi Zibundana zinyamikis eso diana ayi kivuvu kiawu mu ngudi-minswa mi bumutu, mu bunswa ayi mu buzitu bu bumutu, mu budedi bu kinswa kitedi kuidi babakala ayi kuidi bakhieto; Ayi mu kutala ti baboso bakikinini kuvanga madi nkinza ayi kunata-ntwala mu luzingu lwawu kimpwanza ki mnene;</para>
-    <para>Mu kibila ti Batinu boso bangu kinvuka ki Zitsi Zibundana babundidi-thulu mu ngwakunu ayi MYadi kinvuka ki Zitsi zi Bundana mu kusadila lukaku ayi thumunu yi miswa ayi yi maluve ma mutu ayi mvandi bumpwanza bungudi bu mutu;</para>
+    <para>Mu kibila ti mu Pfumu-Mkanda, zitsi zioso zi kinvuka ki Zitsi Zibundana zin’yamikis’ eso diana ayi kivuvu kiawu mu ngudi-minswa mi bumutu, mu bunswa ayi mu buzitu bu bumutu, mu budedi bu kinswa kitedi kuidi babakala ayi kuidi bakhieto; Ayi mu kutala ti baboso bakikinini kuvanga madi nkinza ayi kunata-ntwala mu luzingu lwawu kimpwanza ki m’nene;</para>
+    <para>Mu kibila ti Batinu boso bangu kinvuka ki Zitsi Zibundana babundidi-thulu mu ngwakunu ayi M’Yadi kinvuka ki Zitsi zi Bundana mu kusadila lukaku ayi thumunu yi miswa ayi yi maluve ma mutu ayi mvandi bumpwanza bungudi bu mutu;</para>
     <para>Mu kibila ti ndedokosolo kuidi baboso yi mbadulu yi miswa ayi yi bumpwanza bene bu mutu nkinza yidi, mosi mbwakusulu yi dikanu bene yi baka buku bela;</para>
-    <para>MTINU-LUKUTUNGUNU Wunyamikisa NGYAMUKUSU YI MISWA MI MUTU emimi, dede lukanu lunsadulu kuidi zinvila ayi zitsi zioso, mosi batu boso ayi binvuka biluyalu bi zitsi zioso, bu ba-mi-tebukila monho, basia-ngolo mu-ku-mi-yiyisa mu zinzo-zinkanda, mu-ku-mi-tumina ayi mu-kwe-mi-yonzulanga mu mavanga ma basi tsi-awu ayi mu mavanga ma basi bandi-batu, bakhembo basi kinvuka ki Zitsi Zibundana.</para>
+    <para>MTINU-LUKUTUNGUNU Wun’yamikisa NGYAMUKUSU YI MISWA MI MUTU’ emimi, dede lukanu lun’sadulu kuidi zinvila ayi zitsi zioso, mosi batu boso ayi binvuka biluyalu bi zitsi zioso, bu ba-mi-tebukila monho, basia-ngolo mu-ku-mi-yiyisa mu zinzo-zinkanda, mu-ku-mi-tumina ayi mu-kwe-mi-yonzulanga mu mavanga ma basi tsi-awu ayi mu mavanga ma basi bandi-batu, bakhembo basi kinvuka ki Zitsi Zibundana.</para>
   </preamble>
   <article number="1">
     <title>LUTUMU-MSWA LUTHETI</title>
     <para>Bizingi bioso bisiwu ti batu bambutukanga mu kidedi ki buzitu ayi kibumswa. Bizingi-bene, batu, badi diela ayi tsi-ntima, bafwene kuzingila mbatzi-na-mbatzi-yandi mu mtima bukhomba.</para>
   </article>
   <article number="2">
-    <title>LUTUMU-MSWA LUMMWADI</title>
-    <para>Batu boso babeki dilwaku di kutatila miswa ayi maluve ma-mayamukusu mu MTINU-NGYAMUKUSU ewiwi, mu kukhambu vengula woso mutu, keti mu matedi phila ndimba mkand andi yi nhitu, evo mu matedi bukhieto evo bubala bwandi, evo mu matedi mbembo andi, evo phila nzambi andi, evo mu matedi phila politikandi, evo phila kingudi kiandi, evo mu kibila kinkaka.</para>
-    <para>Ayi vala-sa-siwu luswasunu ko mu kibila ki tswasunu thadulu politika yi batu mu zitsi, evo mu kibila ki tswasunu mswa-nzitumunu yi batu-batu mu zitsi, voti mu kibila ki luswasunu lu mbutukulu evo lu khadulu mutu mu phila-phila tsi, yi kimpwanza, evo yintalu kuidi tsi mka, voti tsi ikoso mu tsi mka.</para>
+    <title>LUTUMU-MSWA LUM’MWADI</title>
+    <para>Batu boso babeki dilwaku di kutatila miswa ayi maluve ma-mayamukusu mu MTINU-NGYAMUKUSU’ ewiwi, mu kukhambu vengula woso mutu, keti mu matedi phila ndimba mkand’ andi yi nhitu, evo mu matedi bukhieto evo bubala bwandi, evo mu matedi mbembo andi, evo phila nzambi andi, evo mu matedi phila politik’andi, evo phila kingudi kiandi, evo mu kibila kinkaka.</para>
+    <para>Ayi vala-sa-siwu luswasunu ko mu kibila ki tswasunu thadulu politika yi batu mu zitsi, evo mu kibila ki tswasunu mswa-nzitumunu yi batu-batu mu zitsi, voti mu kibila ki luswasunu lu mbutukulu evo lu khadulu mutu mu phila-phila tsi, yi kimpwanza, evo yin’talu kuidi tsi mka, voti tsi ikoso mu tsi mka.</para>
   </article>
   <article number="3">
-    <title>LUTUMU-MSWA LUNTATU</title>
+    <title>LUTUMU-MSWA LUN’TATU</title>
     <para>Woso mutu widi mswa kuzinga, ku-yi-yadila na veka mu kimpwanza ayi kuzinga mu lufiatu.</para>
   </article>
   <article number="4">
@@ -34,20 +34,20 @@
     <para>Kwisi ko mutu wala siwu mu buvika; Buvika ayi phila mambu moso matedi buvika bikanduku.</para>
   </article>
   <article number="5">
-    <title>LUTUMU-MSWA LUNTANU</title>
-    <para>Kwisi ko mutu wala tulu mu thovokolo evo mu phasi zimakhemi, zi-kunkitisa bumutu bwandi.</para>
+    <title>LUTUMU-MSWA LUN’TANU</title>
+    <para>Kwisi ko mutu wala tulu mu thovokolo evo mu phasi zimakhemi, zi-kun’kitisa bumutu bwandi.</para>
   </article>
   <article number="6">
-    <title>LUTUMU-MSWA LUNSAMBANU</title>
+    <title>LUTUMU-MSWA LUN’SAMBANU</title>
     <para>Batu boso badi na mswa u-lenda ku-ba-zitusu mu mambu moso matedi bunhitu-mswa bwawu.</para>
   </article>
   <article number="7">
     <title>LUTUMU-MSWA LUTSAMBWADI</title>
-    <para>Batu boso badedakana mu mikaka ayi miswa mi luyalu, mu kukhambu swasunu, badi dede mu butanunu va thalu mswa-mtinu. Baboso badi dede mu luve lu kutanunu vadi loso luswasunu lumbayisa NZA-NGYAMUKUSU eyiyi ayi vadi mavanga moso ma bundima kuidi NGYAMUKUSU eyiyi.</para>
+    <para>Batu boso badedakana mu mikaka ayi miswa mi luyalu, mu kukhambu swasunu, badi dede mu butanunu va thalu mswa-mtinu. Baboso badi dede mu luve lu kutanunu vadi loso luswasunu lumbayisa NZA-NGYAMUKUSU’ eyiyi ayi vadi mavanga moso ma bundima kuidi NGYAMUKUSU’ eyiyi.</para>
   </article>
   <article number="8">
     <title>LUTUMU-MSWA LUNANA</title>
-    <para>Woso kwa mutu widi na luve lu ku-bwe-tomba kusamba mambu mandi mu zinzo zimkanu zi-vyakana, dede buntumina buka-nkanu yi tsi andi.</para>
+    <para>Woso kwa mutu widi na luve lu ku-bwe-tomba kusamba mambu mandi mu zinzo zim’kanu zi-vyakana, dede buntumina buka-nkanu yi tsi andi.</para>
   </article>
   <article number="9">
     <title>LUTUMU-MSWA LUVWA</title>
@@ -55,25 +55,25 @@
   </article>
   <article number="10">
     <title>LUTUMU-MSWA LUKUMI</title>
-    <para>Woso kwa mutu widi mswa, buka woso yandi mutu, mu kufundusu va myalu-nguba mu kitezo kifwana kuidi nzo-mkanu yi songa , inzenga mambu mu budede ayi mu bukiedika bu mavanga mandi, na miswa na buloko bwandi.</para>
+    <para>Woso kwa mutu widi mswa, buka woso yandi mutu, mu kufundusu va m’yalu-nguba mu kitezo kifwana kuidi nzo-m’kanu yi songa , in’zenga mambu mu budede ayi mu bukiedika bu mavanga mandi, na miswa na buloko bwandi.</para>
   </article>
   <article number="11">
     <title>LUTUMU-MSWA LUKUMI-KIMUEKA</title>
     <orderedlist>
       <listitem>
-        <para>Woso mutu umtatu mu mavanga mambi fwene kutwama bongolo dibungu dimbote, nate mbelo-andi immonoso mu procesu yi myalu-nguba, ayi mafwana moso ma butanunu bwandi mantulu-va-tsi.</para>
+        <para>Woso mutu um’tatu mu mavanga mambi fwene kutwama bongolo dibungu dimbote, nate mbelo-andi im’monoso mu procesu yi m’yalu-nguba, ayi mafwana moso ma butanunu bwandi man’tulu-va-tsi.</para>
       </listitem>
       <listitem>
-        <para>Kwisi mutu ko wala komo mu bumbedi mu mambu o ma-zimbukunu evo o ma-khembo sonama dede ti msiku mu thangu yi-ka-ma-sadila, evo mamkambu-ba ti ma mbedoso va thalu mswa-luyalu lu tsi-andi voti va thalu mswa-mtinu luyalu lu tsi-mvimba. Bo bwawu, kwisi-ko luve lu kukoma mutu mu phasi-mswa ilutidi mkata ayi yo imfwene mu thangu yoyawu ikamvola mbi.</para>
+        <para>Kwisi mutu ko wala komo mu bumbedi mu mambu o ma-zimbukunu evo o ma-khembo sonama dede ti msiku mu thangu yi-ka-ma-sadila, evo mam’kambu-ba ti ma mbedoso va thalu mswa-luyalu lu tsi-andi voti va thalu mswa-mtinu luyalu lu tsi-mvimba. Bo bwawu, kwisi-ko luve lu kukoma mutu mu phasi-mswa ilutidi m’kata ayi yo im’fwene mu thangu yoyawu ikam’vola mbi.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="12">
-    <title>LUTUMU-MSWA LUKUMI-KIMMWADI</title>
-    <para>Kwisi-ko mutu wala tatusu mu luzingu lwandi luswama, evo mu mambu mandi ma tsi-nzo ayi mu mambu ma bukanda bwandi, evo mu mambu ma mikanda myandi minsweki, enati vasi kibila kitungu-ko. Mu khotolo batu evo luyalu mu mambu ma ngana mansweki, woso mutu mswa ayi luve kadi kutanunu kwidi lutumu ayi mswa luyalu.</para>
+    <title>LUTUMU-MSWA LUKUMI-KIM’MWADI</title>
+    <para>Kwisi-ko mutu wala tatusu mu luzingu lwandi luswama, evo mu mambu mandi ma tsi-nzo ayi mu mambu ma bukanda bwandi, evo mu mambu ma mikanda myandi min’sweki, enati vasi kibila kitungu-ko. Mu khotolo batu evo luyalu mu mambu ma ngana man’sweki, woso mutu mswa ayi luve kadi kutanunu kwidi lutumu ayi mswa luyalu.</para>
   </article>
   <article number="13">
-    <title>LUTUMU-MSWA LUKUMI-KINTATU</title>
+    <title>LUTUMU-MSWA LUKUMI-KIN’TATU</title>
     <orderedlist>
       <listitem>
         <para>Woso mutu widi luve ayi mswa kudyata ayi kutomba nzo mu yoso-kwa tsi.</para>
@@ -84,32 +84,32 @@
     </orderedlist>
   </article>
   <article number="14">
-    <title>LUTUMU-MSWA LUKUMI-KINYA</title>
+    <title>LUTUMU-MSWA LUKUMI-KIN’YA</title>
     <orderedlist>
       <listitem>
-        <para>Woso mutu mlandukunu kwidi luyalu widi na luve ayi mswa kutinina ayi kutanunu ku tsi-mka.</para>
+        <para>Woso mutu m’landukunu kwidi luyalu widi na luve ayi mswa kutinina ayi kutanunu ku tsi-mka.</para>
       </listitem>
       <listitem>
-        <para>Vangi mswa-bewowo wisi-ko ngolo voti lutelo mu mavada masiwu ti mbivusu innene kwidi lutumu-mswa luntangununwanga ti "direito comum", evo mu mavada mambi madi ndambi yi zikhanu zi mayindu ma kinvuka ki Zitsi Zibundana.</para>
+        <para>Vangi mswa-bewowo wisi-ko ngolo voti lutelo mu mavada masiwu ti mbivusu in’nene kwidi lutumu-mswa lun’tangununwanga ti "direito comum", evo mu mavada mambi madi ndambi yi zikhanu zi mayindu ma kinvuka ki Zitsi Zibundana.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="15">
-    <title>LUTUMU-MSWA LUKUMI-KINTANU</title>
+    <title>LUTUMU-MSWA LUKUMI-KIN’TANU</title>
     <orderedlist>
       <listitem>
         <para>Woso-kwa mutu mswa ayi luve kadi mu kubaka bwisi-tsi bwandi.</para>
       </listitem>
       <listitem>
-        <para>Kwisi-ko mutu mkanduku mu khembo kibila kitungu mu bwisi-tsi bwandi evo mu kubalula bwisi-tsi bwandi mu bwisi-tsi bumkaka.</para>
+        <para>Kwisi-ko mutu m’kanduku mu khembo kibila kitungu mu bwisi-tsi bwandi evo mu kubalula bwisi-tsi bwandi mu bwisi-tsi bumkaka.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="16">
-    <title>LUTUMU-MSWA LUKUMI-KINSAMBANU</title>
+    <title>LUTUMU-MSWA LUKUMI-KIN’SAMBANU</title>
     <orderedlist>
       <listitem>
-        <para>Tona bankituka ditoko ayi ndumba banhieka, kimbakala ayi kikhieto mswa ayi luve lwawu badi mu kukwela ayi kuvanga dikanda, mu kukambu kanduku mu kibila ki mambu ma-tedi phila ndimba yi mkanda nhitu, evo mu kibila ki mambu matedi luswasunu lu bwisi-tsi, evo mu kibila ki matedi luswasunu lu zingwikukulu-mu-zinzambi. Ayi mu dikwela ayi mu mbanusunu dikwela, badi miswa dede.</para>
+        <para>Tona ban’kituka ditoko ayi ndumba banhieka, kimbakala ayi kikhieto mswa ayi luve lwawu badi mu kukwela ayi kuvanga dikanda, mu kukambu kanduku mu kibila ki mambu ma-tedi phila ndimba yi mkanda nhitu, evo mu kibila ki mambu matedi luswasunu lu bwisi-tsi, evo mu kibila ki matedi luswasunu lu zingwikukulu-mu-zinzambi. Ayi mu dikwela ayi mu mbanusunu dikwela, badi miswa dede.</para>
       </listitem>
       <listitem>
         <para>Dikwela disi-ko, enati ba-veka, kikhieto na kimbakala basa di-tya ko.</para>
@@ -145,7 +145,7 @@
         <para>Woso mutu widi na luve ayi mswa mu kimpwanza ki lubundunu ayi ki thwadi ayi badi-andi, kivimba ndembama ikinzuku.</para>
       </listitem>
       <listitem>
-        <para>Kwisi-ko mutu mtisu mu ngolo kukota mu kithwadi.</para>
+        <para>Kwisi-ko mutu m’tisu mu ngolo kukota mu kithwadi.</para>
       </listitem>
     </orderedlist>
   </article>
@@ -156,54 +156,54 @@
         <para>Woso mutu widi mswa ayi luve lubyalu lu tsi-andi, mu bunafeka evo mu bumvwala.</para>
       </listitem>
       <listitem>
-        <para>Woso mutu widi na luve ayi mswa wo-wawu widi badi-andi mu kuba myadi.</para>
+        <para>Woso mutu widi na luve ayi mswa wo-wawu widi badi-andi mu kuba m’yadi.</para>
       </listitem>
       <listitem>
-        <para>Lutya lu basi-tsi lwawu dibandu di buyadi ayi bupfumu bu tsi; Ayi lutya bene lufwene kumonikinanga mu zivoti zikyedika mu tsi ayi zinswekanga butinu ayi bwisi-tsi.</para>
+        <para>Lutya lu basi-tsi lwawu dibandu di buyadi ayi bupfumu bu tsi; Ayi lutya bene lufwene kumonikinanga mu zivoti zikyedika mu tsi ayi zin’swekanga butinu ayi bwisi-tsi.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="22">
-    <title>LUTUMU-MSWA LUMAKUMWADI-KIMMWADI</title>
+    <title>LUTUMU-MSWA LUMAKUMWADI-KIM’MWADI</title>
     <para>Woso mutu, bukadi mwisi-tsi, widi mswa ayi luve kusikumu mu "segurança social", ayi lenda kutomba mbanusunu-nzala yi matedi mu "económico", mu "social" ayi mu "cultural", va mbata lusadusu ayi nguvu yi tsi-andi, yi bukhomba bu tsi-andi ayi zitsi zimka, ayi dede luviakusu lu makanhi ma tsi-na-tsi.</para>
   </article>
   <article number="23">
-    <title>LUTUMU-MSWA LUMAKUMWADI-KINTATU</title>
+    <title>LUTUMU-MSWA LUMAKUMWADI-KIN’TATU</title>
     <orderedlist>
       <listitem>
-        <para>Woso mutu widi na luve na mswa kusala kisalu, kusola kisalu kyandi mu kimpwanza, mu khikununu bufwanhi bwidi ayi kisalu bene ayi mbakulu-andi mu kisalu bene. Woso-kwa mutu widieso luve ayi mswa kukaku ku buphumbulu, voti kukaku ku bukhambu-b-kisalu.</para>
+        <para>Woso mutu widi na luve na mswa kusala kisalu, kusola kisalu kyandi mu kimpwanza, mu khikununu bufwanhi bwidi ayi kisalu bene ayi mbakulu-andi mu kisalu bene. Woso-kwa mutu widi’eso luve ayi mswa kukaku ku buphumbulu, voti kukaku ku bukhambu-b-kisalu.</para>
       </listitem>
       <listitem>
-        <para>Batu boso badi mswa ayi luve kubakila mbakulu ifwene ayi iniedimina ayi kisalu kyawu.</para>
+        <para>Batu boso badi mswa ayi luve kubakila mbakulu ifwene ayi in’iedimina ayi kisalu kyawu.</para>
       </listitem>
       <listitem>
-        <para>Woso mutu nsalanga widi mswa kubaka mfutu uyedimina ayi kisalu kyandi, o un´fwana mu ku-i-zingisa naveka ayi mu kuzingisa dikanda dyandi, ti baka bubela, ayeso mu lusadusu lu bukaku lu "protecção social".</para>
+        <para>Woso mutu n’salanga widi mswa kubaka mfutu uyedimina ayi kisalu kyandi, o un´fwana mu ku-i-zingisa naveka ayi mu kuzingisa dikanda dyandi, ti baka bubela, ay’eso mu lusadusu lu bukaku lu "protecção social".</para>
       </listitem>
       <listitem>
-        <para>Woso-kwa mutu widi na mswa ayi luve kuvanga bimvuka ki thwadi bisadi evo "sindicatu", ayi badi-andi. Widieso mswa kukota mu kimvuka ki "sindicatu", phasi kanwanina-luzingu lwandi lu kisadi.</para>
+        <para>Woso-kwa mutu widi na mswa ayi luve kuvanga bimvuka ki thwadi bisadi evo "sindicatu", ayi badi-andi. Widi’eso mswa kukota mu kimvuka ki "sindicatu", phasi kanwanina-luzingu lwandi lu kisadi.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="24">
-    <title>LUTUMU-MSWA LU MAKUMWADI-KINYA</title>
-    <para>Woso mutu widi mswa ayi luve lu tsakulu ayi lu phundulu imnfutu mu thangu ifwene ayi phila kisalu kyandi.</para>
+    <title>LUTUMU-MSWA LU MAKUMWADI-KIN’YA</title>
+    <para>Woso mutu widi mswa ayi luve lu tsakulu ayi lu phundulu im’nfutu mu thangu ifwene ayi phila kisalu kyandi.</para>
   </article>
   <article number="25">
-    <title>LUTUMU LUMAKUMWADI-KINTANU</title>
+    <title>LUTUMU LUMAKUMWADI-KIN’TANU</title>
     <orderedlist>
       <listitem>
-        <para>Woso mutu widi mswa ayi luve lu kunata phila luzingu lufwana, phila-mweka, mbakulu-andi iduka thanunu buvimpi, bote bwandi bunzingulu. Mbakulu-andi ifwana mbakulu bidya, mbakulu mvwatu, nzo, mbakulu mbukulu kimbevo. Ayi mu buya asyi mu pfwilulu nnuni evo mkazi, ayi mu bununu, ayeso mu phasi zi zimbisa bima byandi bioso, mu kukambu ku lutya lwandi feka, mutu-ewowo mswa thanunu yi kimvuka ki "segurança social" kadi.</para>
+        <para>Woso mutu widi mswa ayi luve lu kunata phila luzingu lufwana, phila-mweka, mbakulu-andi iduka thanunu buvimpi, bote bwandi bunzingulu. Mbakulu-andi ifwana mbakulu bidya, mbakulu mvwatu, nzo, mbakulu mbukulu kimbevo. Ayi mu buya asyi mu pfwilulu n’nuni evo mkazi, ayi mu bununu, ay’eso mu phasi zi zimbisa bima byandi bioso, mu kukambu ku lutya lwandi feka, mutu-ewowo mswa thanunu yi kimvuka ki "segurança social" kadi.</para>
       </listitem>
       <listitem>
-        <para>Mbutu ayi bwana-tsombi bifwene kusadusu mu phila-mka imbote. Ayi bana bambutuka mu dikwela ayi bana bambutuka mu nganda luve ayi mswa dede badi va thalu lusadusu lu kimvuka ki "protecção social".</para>
+        <para>Mbutu ayi bwana-tsombi bifwene kusadusu mu phila-mka imbote. Ayi bana bam’butuka mu dikwela ayi bana bam’butuka mu nganda luve ayi mswa dede badi va thalu lusadusu lu kimvuka ki "protecção social".</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="26">
-    <title>LUTUMU-MSWA LUMAKUMWADI-KINSAMBANU</title>
+    <title>LUTUMU-MSWA LUMAKUMWADI-KIN’SAMBANU</title>
     <orderedlist>
       <listitem>
-        <para>Woso mutu widi mswa kulonga mkanda. Nzo-mkanda ifwene kuba ipholo, ayi mkutu nzo-mkanda itheti bantedilanga ti "ensino elementar". Nzo-mkanda yi "ensino elementar" ikwiku kwidi batu boso yidi. Nzo-mkanda yi "técnico" ayi yi kwiyila kisalu evo "profissional" zifwene kuzibulumu muma moso, kwidi batu boso. Khotolo nzo-mkanda yi lukumu ifwene kwidi baboso dede makanhi mawu.</para>
+        <para>Woso mutu widi mswa kulonga mkanda. Nzo-mkanda ifwene kuba ipholo, ayi mkutu nzo-mkanda itheti ban’tedilanga ti "ensino elementar". Nzo-mkanda yi "ensino elementar" ikwiku kwidi batu boso yidi. Nzo-mkanda yi "técnico" ayi yi kwiyila kisalu evo "profissional" zifwene kuzibulumu muma moso, kwidi batu boso. Khotolo nzo-mkanda yi lukumu ifwene kwidi baboso dede makanhi mawu.</para>
       </listitem>
       <listitem>
         <para>Nzo-mkanda ifwene kusongisa ayi kunatisa batu mu nzila bumutu-tungu, ayi mu khwetolo miswa ayi maluve ma kinvuka ki Zitsi Zibundana, mu kutwadisa batu mu nzila ngwizunu, mu nzila mlenvo ayi mu nzila bukhomba ayi bundembama.</para>
@@ -226,7 +226,7 @@
   </article>
   <article number="28">
     <title>LUTUMU-MSWA LUMAKUMWADI-KINANA</title>
-    <para>Woso mutu widi mswa ayi luve ku sya-dyana ti vadi phila ngyatusulu nza ilenda tumisa ayi vangisa miswa ayi maluve ma Ngyamukusueyiyi.</para>
+    <para>Woso mutu widi mswa ayi luve ku sya-dyana ti vadi phila ngyatusulu nza ilenda tumisa ayi vangisa miswa ayi maluve ma Ngyamukusu’eyiyi.</para>
   </article>
   <article number="29">
     <title>LUTUMU-MSWA LUMAKUMWADI-KIVWA</title>
@@ -235,15 +235,15 @@
         <para>Woso mutu widi na zithumu zi-ka-fwene kusadila va meso ma bundiku bwandi, khinu kalendi baka-ko bu kukonzukila um bumutu-tungu bwandi.</para>
       </listitem>
       <listitem>
-        <para>Thumukunu miswa ayi maluve mosoemama yidi mu mkamba misiku mi luyalu, o minnata-ntuala buzitu bu batu-i-batu, bunswa ayi buphwanza, ayi buvumi bu bifu-bi-mbote, ayi buvumi mu tsi i bu-"democracia".</para>
+        <para>Thumukunu miswa ayi maluve moso’emama yidi mu mkamba misiku mi luyalu, o min’nata-ntuala buzitu bu batu-i-batu, bunswa ayi buphwanza, ayi buvumi bu bifu-bi-mbote, ayi buvumi mu tsi i bu-"democracia".</para>
       </listitem>
       <listitem>
-        <para>Kanikito kusadila miswa ayi maluve mosoemama mu phila mweka ivyakasana ayi mabanza mangudi mandi, o ma kimvuka ki Zitsi Zibundana.</para>
+        <para>Kanikito kusadila miswa ayi maluve moso’emama mu phila mweka ivyakasana ayi mabanza mangudi mandi, o ma kimvuka ki Zitsi Zibundana.</para>
       </listitem>
     </orderedlist>
   </article>
   <article number="30">
     <title>LUTUMU-MSWA LUMAKUMATATU</title>
-    <para>Kadi msiku wu NZA-NGYAMUKUSUeyiyi ulenda vumbulu mu phumbudulu innatisa tsi vo dingumba mu mavanga ma tholomono miswa ayi maluve bene.</para>
+    <para>Kadi msiku wu NZA-NGYAMUKUSU’eyiyi ulenda vumbulu mu phumbudulu in’natisa tsi vo dingumba mu mavanga ma tholomono miswa ayi maluve bene.</para>
   </article>
 </udhr>

--- a/data/udhr/udhr_sco.xml
+++ b/data/udhr/udhr_sco.xml
@@ -5,7 +5,7 @@
 
   <note>
     <para>Adoptit and proclaimed by General Assemlie resolution 217A (III) o 10 December 1948.</para>
-    <para>On December 10, 1948 the General Assemlie o the Unitit Nations adoptit and proclaimed the Universal Declaration o Human Richts shawn hereablo in its ful text. Efter this historic act the Assemlie cried on aw Member States tae publicise the text o the Declaration and tae gar it be disseminatit, displayed, read and exponed principally in scuils and ither learning institutions, wi nae distinction on grunds o the political status o countries or territours.</para>
+    <para>On December 10, 1948 the General Assemlie o the Unitit Nations adoptit and proclaimed the Universal Declaration o Human Richts shawn hereablo in its ful text. Efter this historic act the Assemlie cried on aw Member States tae publicise the text o the Declaration and tae gar it be ‘disseminatit, displayed, read and exponed principally in scuils and ither learning institutions, wi nae distinction on grunds o the political status o countries or territours.</para>
   </note>
 
   <preamble>


### PR DESCRIPTION
Three XML files contain incorrectly encoded quotation marks.

- `data/udhr/udhr_kng_AO.xml` (Koongo - Angola)
- `data/udhr/udhr_sco.xml` (Scots)
- `data/udhr/udhr_kea.xml` (Kabuverdianu)

For example::

    >>> open('data/udhr/udhr_kng_AO.xml','rb').read()[-171:]
    b'ara>Kadi msiku wu NZA-NGYAMUKUSU\xc2\x92eyiyi ulenda vumbulu mu phumbudulu in\xc2\x92natisa tsi vo dingumba mu mavanga ma tholomono miswa ayi maluve bene.</para>\n  </article>\n</udhr>\n'

Here, the invalid byte sequence in the raw file is seen, ``\xc2\x92``.

This causes unintended display of values in many applications, usually it is hidden (such as displayed by github viewer and editor), but more advanced editors and text viewers like vim and less show it as an errant control character.

<img width="1490" height="1166" alt="Screenshot_20251106_121947" src="https://github.com/user-attachments/assets/3464af5f-f4fe-4fdd-99e1-f65c874abb73" />

I hope this is not too technical for you, please do not hesitate to ask questions that might help.

Solution
--------

Replace the invalid byte sequences in the XML files with the correct UTF-8 bytes.  Python was used fix the affected files:

```python
FILES_TO_FIX = [
    'data/udhr/udhr_kng_AO.xml',
    'data/udhr/udhr_sco.xml',
    'data/udhr/udhr_kea.xml',
]

REPLACEMENTS = [
    (b'\xc2\x91', b'\xe2\x80\x98'),  # U+0091 -> U+2018 (left single quote)
    (b'\xc2\x92', b'\xe2\x80\x99'),  # U+0092 -> U+2019 (right single quote)
]

def fix_file(filename):
    with open(filename, 'rb') as f:
        data = f.read()

    for find_bytes, replace_bytes in REPLACEMENTS:
        data = data.replace(find_bytes, replace_bytes)

    with open(filename, 'wb') as f:
        f.write(data)

for filename in FILES_TO_FIX:
    fix_file(filename)
```